### PR TITLE
PORT-1975 Remove unnecessary property in example

### DIFF
--- a/docs/complete-use-cases/software-catalog.md
+++ b/docs/complete-use-cases/software-catalog.md
@@ -70,10 +70,6 @@ The Blueprint JSON provided below already includes the Relations between the dif
         "format": "url",
         "description": "Link to the service repo on GitHub"
       },
-      "responsibleTeam": {
-        "type": "string",
-        "title": "Responsible Team"
-      },
       "onCall": {
         "type": "string",
         "title": "Current On-Call"
@@ -449,7 +445,6 @@ title: Notification Service
 blueprint: Service
 properties:
   slackChannel: "https://yourslack.slack.com/archives/CHANNEL-ID"
-  responsibleTeam: "Infra"
   onCall: "Mor P"
   coreLanguage: "Python"
   businessDomain: "Infra"


### PR DESCRIPTION
# Description

Remove unnecessary property in software catalog example

## Added docs pages

Please also include the path for the added docs

## Updated docs pages

Please also include the path for the updated docs

- Software Catalog (`/complete-use-cases/software-catalog`)
