### PR TITLE
PORT-2798 Make self-service-actions deep dive a category

### DIFF
--- a/docs/platform-overview.md
+++ b/docs/platform-overview.md
@@ -50,10 +50,10 @@ Port Self-Service Actions are enabled using several convenient integrations with
 - [**Execution Agent**](./self-service-actions/webhook/port-execution-agent/) - our execution agent provides you with a secure and convenient way to listen and act on invocations of Self-Service Actions and changes in the software catalog;
 - [**Kafka Actions**](./self-service-actions/kafka/) - Port manages a Kafka Topic per customer that publishes the execution run requests.
   You can listen to a Kafka Topic with any code platform you wish to use, and also use it as a trigger for a serverless function. For example, AWS Lambda.
-- [**GitHub Workflow Actions**](./self-service-actions/github-workflow/) - [Port's GitHub application](./exporters/github-exporter/installation.md) can trigger a [GitHub workflow](https://docs.github.com/en/actions/using-workflows) using a customer provided input and [`port_payload`](./self-service-actions/self-service-actions-deep-dive.md#action-message-structure).
+- [**GitHub Workflow Actions**](./self-service-actions/github-workflow/) - [Port's GitHub application](./exporters/github-exporter/installation.md) can trigger a [GitHub workflow](https://docs.github.com/en/actions/using-workflows) using a customer provided input and [`port_payload`](./self-service-actions/self-service-actions-deep-dive/self-service-actions-deep-dive.md#action-message-structure).
 
 :::tip
-To learn more about the Self-Service Actions and more, refer to the [Self-Service Actions](./self-service-actions/) page and the [Self-Service Actions Deep Dive](./self-service-actions/self-service-actions-deep-dive.md).
+To learn more about the Self-Service Actions and more, refer to the [Self-Service Actions](./self-service-actions/) page and the [Self-Service Actions Deep Dive](./self-service-actions/self-service-actions-deep-dive/self-service-actions-deep-dive.md).
 :::
 
 ## Integrations

--- a/docs/self-service-actions/github-workflow/examples/run-service-deployment.md
+++ b/docs/self-service-actions/github-workflow/examples/run-service-deployment.md
@@ -76,9 +76,9 @@ jobs:
 
 :::note
 Pay attention to the additional parameter in the workflow called `port_payload`.
-This parameter is completed by default with [Port's action message](../../self-service-actions-deep-dive.md#action-message-structure).
+This parameter is completed by default with [Port's action message](../../self-service-actions-deep-dive/self-service-actions-deep-dive.md#action-message-structure).
 You can disable it by specifying `"omitPayload": true` in Port's action definition.
-For more details click [here](../../self-service-actions-deep-dive.md#invocation-method-structure-fields)
+For more details click [here](../../self-service-actions-deep-dive/self-service-actions-deep-dive.md#invocation-method-structure-fields)
 :::
 
 ## Create a deployment Blueprint

--- a/docs/self-service-actions/github-workflow/github-workflow.md
+++ b/docs/self-service-actions/github-workflow/github-workflow.md
@@ -1,6 +1,6 @@
 # GitHub Workflow Self-Service Actions
 
-[Port's GitHub application](../../exporters/github-exporter/installation.md) can trigger a [GitHub workflow](https://docs.github.com/en/actions/using-workflows) using a customer provided input and [`port_payload`](../../self-service-actions/self-service-actions-deep-dive.md#action-message-structure).
+[Port's GitHub application](../../exporters/github-exporter/installation.md) can trigger a [GitHub workflow](https://docs.github.com/en/actions/using-workflows) using a customer provided input and [`port_payload`](../../self-service-actions/self-service-actions-deep-dive/self-service-actions-deep-dive.md#action-message-structure).
 
 ![Port Kafka Architecture](../../../static/img/self-service-actions/portGithubWorkflowArchitecture.png)
 

--- a/docs/self-service-actions/self-service-actions-deep-dive/_category_.json
+++ b/docs/self-service-actions/self-service-actions-deep-dive/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Self-Service Actions Deep Dive",
+  "position": 1
+}

--- a/docs/self-service-actions/self-service-actions-deep-dive/action-runs-tutorial.md
+++ b/docs/self-service-actions/self-service-actions-deep-dive/action-runs-tutorial.md
@@ -7,13 +7,13 @@ sidebar_position: 2
 Invoking a Port Self-Service Action creates an `actionRun` object inside Port.
 
 :::tip
-To learn more about configuring Self-Service Actions, refer to the [Depp Dive](./self-service-actions-deep-dive.md). After configuring a Self-Service Action, invoking it will generate an `actionRun` which you can learn more about in this tutorial.
+To learn more about configuring Self-Service Actions, refer to the [Depp Dive](./self-service-actions-deep-dive). After configuring a Self-Service Action, invoking it will generate an `actionRun` which you can learn more about in this tutorial.
 :::
 
 You can find all existing action runs in one of the following methods:
 
 1. Select the Runs tab on the Audit Log page;
-2. Select the Runs tab of a specific Entity on its [Specific Entity Page](../software-catalog/entity/entity.md#entity-page);
+2. Select the Runs tab of a specific Entity on its [Specific Entity Page](../../software-catalog/entity/entity.md#entity-page);
 3. When you invoke a Self-Service Action from the UI, a toast will appear on the page, with the link to the action run that corresponds to the run of the Self-Service Action.
 
 This tutorial will teach you how to use Port's API to obtain existing action runs, update them with additional metadata and information about the results of the invoked Self-Service Action, and mark them as completed or failed to keep a consistent history of invoked Self-Service Actions and their status.
@@ -517,7 +517,7 @@ if __name__ == '__main__':
 
 Now when you look at the run log of the action run, you will see the information of the newly created Entity:
 
-![Developer portal action run log](../../static/img/self-service-actions/action_run_log.png)
+![Developer portal action run log](../../../static/img/self-service-actions/action_run_log.png)
 
 :::tip
 In the example above we created just one Entity, but it is possible to create, update or delete multiple Entities as part of the steps taken by a single action run, and all of these changes will be reflected in the action run log.

--- a/docs/self-service-actions/self-service-actions-deep-dive/action-runs-tutorial.md
+++ b/docs/self-service-actions/self-service-actions-deep-dive/action-runs-tutorial.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 Invoking a Port Self-Service Action creates an `actionRun` object inside Port.
 
 :::tip
-To learn more about configuring Self-Service Actions, refer to the [Depp Dive](./self-service-actions-deep-dive). After configuring a Self-Service Action, invoking it will generate an `actionRun` which you can learn more about in this tutorial.
+To learn more about configuring Self-Service Actions, refer to the [Depp Dive](./self-service-actions-deep-dive.md). After configuring a Self-Service Action, invoking it will generate an `actionRun` which you can learn more about in this tutorial.
 :::
 
 You can find all existing action runs in one of the following methods:

--- a/docs/self-service-actions/self-service-actions-deep-dive/self-service-actions-deep-dive.md
+++ b/docs/self-service-actions/self-service-actions-deep-dive/self-service-actions-deep-dive.md
@@ -14,7 +14,7 @@ sidebar_label: Self-Service Actions Deep Dive
 :::info
 This deep dive's purpose is to teach you how to configure Self-Service Actions, understand their structure and the different options they offer you.
 
-To learn how to update the status of an existing Self-Service Action invocation, refer to the [Action Runs Tutorial](./action-runs-tutorial.md)
+To learn how to update the status of an existing Self-Service Action invocation, refer to the [Action Runs Tutorial](./action-runs-tutorial)
 :::
 
 ## Configuring a new self-service action
@@ -28,7 +28,7 @@ For example, let’s create 2 Blueprints and connect them to each other:
 - **Blueprint #1**: Microservice;
 - **Blueprint #2**: Deployment.
 
-![Target blueprints and relations expanded](../../static/img/self-service-actions/setting-self-service-actions-in-port/targetBlueprintsAndRelationExpanded.png)
+![Target blueprints and relations expanded](../../../static/img/self-service-actions/setting-self-service-actions-in-port/targetBlueprintsAndRelationExpanded.png)
 
 <details>
 <summary>An example Microservice Blueprint</summary>
@@ -131,7 +131,7 @@ For example, let’s create 2 Blueprints and connect them to each other:
 
 In order to create a Self-Service Action, go to the DevPortal Setup page, expand the Microservice Blueprint and click on the `Create action` button as shown below:
 
-![Create action button on blueprint marked](../../static/img/self-service-actions/setting-self-service-actions-in-port/createActionOnBlueprintButtonMarked.png)
+![Create action button on blueprint marked](../../../static/img/self-service-actions/setting-self-service-actions-in-port/createActionOnBlueprintButtonMarked.png)
 
 After clicking the button, you should see an editor with an empty array (`[]`) appear, that's where we will add our Self-Service Action
 
@@ -169,15 +169,15 @@ Here is an action array with a `CREATE` action already filled in:
 
 This is how the JSON editor looks after submitting the Self-Service Action:
 
-![Action editor filled](../../static/img/self-service-actions/setting-self-service-actions-in-port/microserviceEditorWithCreateAction.png)
+![Action editor filled](../../../static/img/self-service-actions/setting-self-service-actions-in-port/microserviceEditorWithCreateAction.png)
 
 Now when you go to the Microservices Blueprint page, you will see a new button - `Create Microservice`:
 
-![Create button marked](../../static/img/self-service-actions/setting-self-service-actions-in-port/microservicePageWithCreateMarked.png)
+![Create button marked](../../../static/img/self-service-actions/setting-self-service-actions-in-port/microservicePageWithCreateMarked.png)
 
 After clicking the `Create Microservice` option, we will see a form with the inputs specified when the new action was entered to the actions array:
 
-![Action create form](../../static/img/self-service-actions/setting-self-service-actions-in-port/actionCreateForm.png)
+![Action create form](../../../static/img/self-service-actions/setting-self-service-actions-in-port/actionCreateForm.png)
 
 ### More Self-Service Actions
 
@@ -260,11 +260,11 @@ Now when we go back to the Microservice page, if we click on the 3 dots next to 
 
 **Day-2:**
 
-![Day-2 button marked](../../static/img/self-service-actions/setting-self-service-actions-in-port/day-2-action-marked.png)
+![Day-2 button marked](../../../static/img/self-service-actions/setting-self-service-actions-in-port/day-2-action-marked.png)
 
 **Delete:**
 
-![Delete button marked](../../static/img/self-service-actions/setting-self-service-actions-in-port/delete-action-marked.png)
+![Delete button marked](../../../static/img/self-service-actions/setting-self-service-actions-in-port/delete-action-marked.png)
 
 #### Add multiple Self-Service Actions of the same type
 
@@ -331,7 +331,7 @@ Now when you go to the Microservices Blueprint page, you will see 2 new buttons 
 
 <center>
 
-![Multiple Create Actions](../../static/img/self-service-actions/setting-self-service-actions-in-port/multiple-create-actions.png)
+![Multiple Create Actions](../../../static/img/self-service-actions/setting-self-service-actions-in-port/multiple-create-actions.png)
 
 </center>
 
@@ -375,35 +375,35 @@ The basic structure of a Self-Service Action:
 
 ### Structure table
 
-| Field              | Description                                                                                                                                                                                      |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `id`               | Internal Action ID                                                                                                                                                                               |
-| `identifier`       | Action identifier                                                                                                                                                                                |
-| `title`            | Action title                                                                                                                                                                                     |
-| `icon`             | Action icon                                                                                                                                                                                      |
-| `userInputs`       | An object containing `properties` and `required` keys following the standard JSON schema format as seen in [Blueprint structure](../software-catalog/blueprint/blueprint.md#blueprint-structure) |
-| `invocationMethod` | Defines the destination where invocations of the Self-Service Action will be delivered, see [invocation method](#invocation-method) for details                                                  |
-| `trigger`          | The type of the action: `CREATE`, `DAY-2` or `DELETE`                                                                                                                                            |
-| `description`      | Action description                                                                                                                                                                               |
+| Field              | Description                                                                                                                                                                                         |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`               | Internal Action ID                                                                                                                                                                                  |
+| `identifier`       | Action identifier                                                                                                                                                                                   |
+| `title`            | Action title                                                                                                                                                                                        |
+| `icon`             | Action icon                                                                                                                                                                                         |
+| `userInputs`       | An object containing `properties` and `required` keys following the standard JSON schema format as seen in [Blueprint structure](../../software-catalog/blueprint/blueprint.md#blueprint-structure) |
+| `invocationMethod` | Defines the destination where invocations of the Self-Service Action will be delivered, see [invocation method](#invocation-method) for details                                                     |
+| `trigger`          | The type of the action: `CREATE`, `DAY-2` or `DELETE`                                                                                                                                               |
+| `description`      | Action description                                                                                                                                                                                  |
 
 ### Properties structure table
 
 The following table includes the different fields that can be specified in the `properties` key:
 
-| Field                    | Description                                                                                                                                                                                                         |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`                   | All the [types](../software-catalog/blueprint/blueprint.md#property-types) Port supports - `string`, `number`, `boolean`, etc...                                                                                    |
-| `title`                  | The title shown in the form when activating the Self-Service Action                                                                                                                                                 |
-| `format`                 | Specific data format to pair with some of the available types. You can explore all formats in the [String Formats](#string-formats) section                                                                         |
-| `blueprint`              | Identifier of an existing Blueprint to fetch Entities from                                                                                                                                                          |
-| `description` (Optional) | Extra description for the requested property                                                                                                                                                                        |
-| `default` (Optional)     | Default value                                                                                                                                                                                                       |
-| `enum` (Optional)        | A list of predefined values the user can choose from, same format as [enum](../software-catalog/blueprint/blueprint.md#enum)                                                                                        |
-| `icon` (Optional)        | Icon for the user input property. Icon options: `Airflow, Ansible, Argo, Aws, Azure, Blueprint, Bucket, Cloud,...` <br /><br />See the [full icon list](../software-catalog/blueprint/blueprint.md#full-icon-list). |
+| Field                    | Description                                                                                                                                                                                                            |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`                   | All the [types](../../software-catalog/blueprint/blueprint.md#property-types) Port supports - `string`, `number`, `boolean`, etc...                                                                                    |
+| `title`                  | The title shown in the form when activating the Self-Service Action                                                                                                                                                    |
+| `format`                 | Specific data format to pair with some of the available types. You can explore all formats in the [String Formats](#string-formats) section                                                                            |
+| `blueprint`              | Identifier of an existing Blueprint to fetch Entities from                                                                                                                                                             |
+| `description` (Optional) | Extra description for the requested property                                                                                                                                                                           |
+| `default` (Optional)     | Default value                                                                                                                                                                                                          |
+| `enum` (Optional)        | A list of predefined values the user can choose from, same format as [enum](../../software-catalog/blueprint/blueprint.md#enum)                                                                                        |
+| `icon` (Optional)        | Icon for the user input property. Icon options: `Airflow, Ansible, Argo, Aws, Azure, Blueprint, Bucket, Cloud,...` <br /><br />See the [full icon list](../../software-catalog/blueprint/blueprint.md#full-icon-list). |
 
 ### Special formats
 
-In addition to the formats that were introduced in [Blueprint string property formats](../software-catalog/blueprint/blueprint.md#string-property-formats), Port's Self-Service Actions also support the following special formats:
+In addition to the formats that were introduced in [Blueprint string property formats](../../software-catalog/blueprint/blueprint.md#string-property-formats), Port's Self-Service Actions also support the following special formats:
 
 | `type`       | Description                                  | Example values                                  |
 | ------------ | -------------------------------------------- | ----------------------------------------------- |
@@ -457,16 +457,16 @@ The `invocationMethod` object controls where Self-Service Actions are reported t
 
 The `invocationMethod` supports 3 configurations:
 
-- [Webhook](./webhook/webhook.md)
-- [Kafka](./kafka/kafka.md)
-- [GitHub](./github-workflow/github-workflow.md)
+- [Webhook](../webhook/webhook.md)
+- [Kafka](../kafka/kafka.md)
+- [GitHub](../github-workflow/github-workflow.md)
 
 ### Invocation method structure fields
 
 | Field                  | Type      | Description                                                                                                                                                                                                                                                                                  | Example values                      |
 | ---------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
 | `type`                 | `string`  | Defines the self-service action destination type                                                                                                                                                                                                                                             | Either `WEBHOOK`, `KAFKA`, `GITHUB` |
-| `agent`                | `boolean` | Defines whether to use [Port Agent](./webhook/port-execution-agent/port-execution-agent.md) for execution or not. <br></br> Can only be added if `type` is set to `WEBHOOK`                                                                                                                  | Either `true` or `false`            |
+| `agent`                | `boolean` | Defines whether to use [Port Agent](../webhook/port-execution-agent/port-execution-agent.md) for execution or not. <br></br> Can only be added if `type` is set to `WEBHOOK`                                                                                                                 | Either `true` or `false`            |
 | `url`                  | `string`  | Defines the webhook URL to which Port sends self-service actions to via HTTP POST request. <br></br> Can be added only if `type` is set to `WEBHOOK`                                                                                                                                         | `https://example.com`               |
 | `org`                  | `string`  | Defines the GitHub organization name. <br></br> Can be added only if `type` is set to `GITHUB`                                                                                                                                                                                               | `port-labs`                         |
 | `repo`                 | `string`  | Defines the GitHub repository name. <br></br> Can be added only if `type` is set to `GITHUB`                                                                                                                                                                                                 | `port-docs`                         |
@@ -487,7 +487,7 @@ For example, you can deploy a new version of your microservice when a `CREATE` a
 
 The action is triggered from the page matching the Blueprint we configured the action on:
 
-![Create button marked](../../static/img/self-service-actions/setting-self-service-actions-in-port/microservicePageWithCreateMarked.png)
+![Create button marked](../../../static/img/self-service-actions/setting-self-service-actions-in-port/microservicePageWithCreateMarked.png)
 
 :::tip create vs register
 When you define a `CREATE` action on a Blueprint, when viewing the Blueprint page you will notice that the create button now has a dropdown. Two options will appear: `Register` and `Create`:
@@ -502,13 +502,13 @@ When you define a `CREATE` action on a Blueprint, when viewing the Blueprint pag
 
 When clicking the `Create Microservice` option, we will see a form with the inputs we specified when we entered the new action to the actions array:
 
-![Action create form](../../static/img/self-service-actions/setting-self-service-actions-in-port/actionCreateForm.png)
+![Action create form](../../../static/img/self-service-actions/setting-self-service-actions-in-port/actionCreateForm.png)
 
 ### DAY-2 action
 
 The action can be triggered by selecting it from the sub-menu of an existing Entity:
 
-![Day-2 button marked](../../static/img/self-service-actions/setting-self-service-actions-in-port/day-2-action-marked.png)
+![Day-2 button marked](../../../static/img/self-service-actions/setting-self-service-actions-in-port/day-2-action-marked.png)
 
 :::note DAY-2 actions
 All Day-2 operations will appear in this sub-menu.
@@ -518,7 +518,7 @@ All Day-2 operations will appear in this sub-menu.
 
 The action can be triggered by selecting it from the sub-menu of an existing Entity:
 
-![Delete button marked](../../static/img/self-service-actions/setting-self-service-actions-in-port/delete-action-marked.png)
+![Delete button marked](../../../static/img/self-service-actions/setting-self-service-actions-in-port/delete-action-marked.png)
 
 ## Action message structure
 
@@ -629,5 +629,5 @@ Here is an example `payload` object for a `CREATE` action:
 
 Now that you have the basics of Self-Service Actions, you can:
 
-- Learn about how to update a Self-Service Action after it started, by interacting with the [action run](./action-runs-tutorial.md) object;
-- Refer to our examples for some practical use-cases - [Setting up a basic execution runner using AWS Lambda](../self-service-actions/kafka/examples/execution-basic-runner-using-aws-lambda.md).
+- Learn about how to update a Self-Service Action after it started, by interacting with the [action run](./action-runs-tutorial) object;
+- Refer to our examples for some practical use-cases - [Setting up a basic execution runner using AWS Lambda](../../self-service-actions/kafka/examples/execution-basic-runner-using-aws-lambda.md).

--- a/docs/self-service-actions/self-service-actions-deep-dive/self-service-actions-deep-dive.md
+++ b/docs/self-service-actions/self-service-actions-deep-dive/self-service-actions-deep-dive.md
@@ -416,17 +416,17 @@ The basic structure of a Self-Service Action:
 
 ### Structure table
 
-| Field              | Description                                                                                                                                                                                      |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `id`               | Internal Action ID                                                                                                                                                                               |
-| `identifier`       | Action identifier                                                                                                                                                                                |
-| `title`            | Action title                                                                                                                                                                                     |
-| `icon`             | Action icon                                                                                                                                                                                      |
-| `userInputs`       | An object containing `properties` and `required` keys following the standard JSON schema format as seen in [Blueprint structure](../software-catalog/blueprint/blueprint.md#blueprint-structure) |
-| `invocationMethod` | Defines the destination where invocations of the Self-Service Action will be delivered, see [invocation method](#invocation-method) for details                                                  |
-| `trigger`          | The type of the action: `CREATE`, `DAY-2` or `DELETE`                                                                                                                                            |
-| `requiredApproval` | Whether the action requires approval or not                                                                                                                                                      |
-| `description`      | Action description                                                                                                                                                                               |
+| Field              | Description                                                                                                                                                                                         |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`               | Internal Action ID                                                                                                                                                                                  |
+| `identifier`       | Action identifier                                                                                                                                                                                   |
+| `title`            | Action title                                                                                                                                                                                        |
+| `icon`             | Action icon                                                                                                                                                                                         |
+| `userInputs`       | An object containing `properties` and `required` keys following the standard JSON schema format as seen in [Blueprint structure](../../software-catalog/blueprint/blueprint.md#blueprint-structure) |
+| `invocationMethod` | Defines the destination where invocations of the Self-Service Action will be delivered, see [invocation method](#invocation-method) for details                                                     |
+| `trigger`          | The type of the action: `CREATE`, `DAY-2` or `DELETE`                                                                                                                                               |
+| `requiredApproval` | Whether the action requires approval or not                                                                                                                                                         |
+| `description`      | Action description                                                                                                                                                                                  |
 
 ### Properties structure table
 

--- a/docs/self-service-actions/self-service-actions.md
+++ b/docs/self-service-actions/self-service-actions.md
@@ -8,13 +8,13 @@ In Port, you can make your Software Catalog active by defining Self-Service Acti
 
 Port enables developer Self-Service in 2 distinct ways:
 
-- [Self-Service Actions](./self-service-actions-deep-dive.md) - configure **Create** and **Delete** actions to provision and control the resource usage in your organization. Configure **Day-2 Operations** to keep your infrastructure up-to-date.
+- [Self-Service Actions](./self-service-actions-deep-dive/self-service-actions-deep-dive.md) - configure **Create** and **Delete** actions to provision and control the resource usage in your organization. Configure **Day-2 Operations** to keep your infrastructure up-to-date.
 - [Real-time Changelog](./kafka/examples/changelog-basic-change-listener-using-aws-lambda.md) - every change that occurs in Port generates a new audit log entry.
 
 ## Getting started
 
-- To learn more about Self-Service Actions, their structure, and how to start configuring your Self-Service Actions, refer to the [deep dive](./self-service-actions-deep-dive.md);
-- To learn how to interact with action run objects, update the status of invoked Self-Service Actions and keep track of Entities created and modified by Self-Service Action runs, refer to the [Action Runs Tutorial](./action-runs-tutorial.md).
+- To learn more about Self-Service Actions, their structure, and how to start configuring your Self-Service Actions, refer to the [deep dive](./self-service-actions-deep-dive/self-service-actions-deep-dive.md);
+- To learn how to interact with action run objects, update the status of invoked Self-Service Actions and keep track of Entities created and modified by Self-Service Action runs, refer to the [Action Runs Tutorial](./self-service-actions-deep-dive/action-runs-tutorial.md).
 
 ## Architecture and technology-specific Self-Service Actions
 

--- a/docs/self-service-actions/webhook/local-debugging-webhook.md
+++ b/docs/self-service-actions/webhook/local-debugging-webhook.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 In this guide, we will show you how to debug Webhook Self-Service Actions that are sent from Port locally.
 
-This example contains the initial steps to set up a standard Self-Service Action use case, following it shows how to locally debug the payload sent by Port through the webhook [invocation method](../self-service-actions-deep-dive.md#invocation-method).
+This example contains the initial steps to set up a standard Self-Service Action use case, following it shows how to locally debug the payload sent by Port through the webhook [invocation method](../self-service-actions-deep-dive/self-service-actions-deep-dive.md#invocation-method).
 
 ## Prerequisites
 

--- a/docs/self-service-actions/webhook/port-execution-agent/quickstart.md
+++ b/docs/self-service-actions/webhook/port-execution-agent/quickstart.md
@@ -44,7 +44,7 @@ helm install my-port-agent port-labs/port-agent \
 
 3. Follow one of the guides below:
 
-- [Self-Service Actions Deep Dive](../../self-service-actions-deep-dive.md) - set up a Blueprint and Self-Service Actions.
+- [Self-Service Actions Deep Dive](../../self-service-actions-deep-dive/self-service-actions-deep-dive.md) - set up a Blueprint and Self-Service Actions.
 - [Changelog Listener](../examples/changelog-listener.md) - create a Blueprint with `changelogDestination` to listen and act on changes in the software catalog.
 
 When using the execution agent, in the `url` field you need to provide a URL to a service (for example, a REST API) that will accept the invocation event.
@@ -55,8 +55,8 @@ When using the execution agent, in the `url` field you need to provide a URL to 
 :::note
 **IMPORTANT**: To make use of the **Port execution agent**, you need to configure:
 
-- [Self-Service Action invocation method](../../self-service-actions-deep-dive.md#invocation-method-structure-fields) / [Change Log](../../../software-catalog/blueprint/blueprint.md#changelog-destination) destination `type` field value should be equal to `WEBHOOK`.
-- [Self-Service Action invocation method](../../self-service-actions-deep-dive.md#invocation-method-structure-fields) / [Change Log](../../../software-catalog/blueprint/blueprint.md#changelog-destination) `agent` field value should be equal to `true`.
+- [Self-Service Action invocation method](../../self-service-actions-deep-dive/self-service-actions-deep-dive.md#invocation-method-structure-fields) / [Change Log](../../../software-catalog/blueprint/blueprint.md#changelog-destination) destination `type` field value should be equal to `WEBHOOK`.
+- [Self-Service Action invocation method](../../self-service-actions-deep-dive/self-service-actions-deep-dive.md#invocation-method-structure-fields) / [Change Log](../../../software-catalog/blueprint/blueprint.md#changelog-destination) `agent` field value should be equal to `true`.
 
 For example:
 

--- a/docs/software-catalog/blueprint/blueprint.md
+++ b/docs/software-catalog/blueprint/blueprint.md
@@ -784,7 +784,7 @@ If you don't want to send changelog events to any destination, you can simply re
 | `agent` | `boolean` | Defines whether to use [Port Agent](../../self-service-actions/webhook/port-execution-agent/port-execution-agent.md) for execution or not. <br></br> Can only be added if `type` is set to `WEBHOOK` | Either `true` or `false`    |
 | `url`   | `string`  | Defines the webhook URL where Port sends changelog events to via HTTP POST request. <br></br> Can be added only if `type` is set to `WEBHOOK`                                                        | `https://example.com`       |
 
-For more information about Port's changelog capabilities, refer to the [Self-Service Actions deep dive](../../self-service-actions/self-service-actions-deep-dive.md) page.
+For more information about Port's changelog capabilities, refer to the [Self-Service Actions deep dive](../../self-service-actions/self-service-actions-deep-dive/self-service-actions-deep-dive.md) page.
 
 ## Mirror properties
 

--- a/docs/software-catalog/blueprint/timer-properties.md
+++ b/docs/software-catalog/blueprint/timer-properties.md
@@ -43,7 +43,7 @@ In the following example, we will create a timer property called locked, that wi
 
 After 2 hours, the property status will change to `Expired`, and an event of `Timer Expired` will be sent to the [ChangeLog](../blueprint/blueprint.md#changelog-destination).
 
-The following [action invocation body](../../self-service-actions/self-service-actions-deep-dive.md#self-service-action-run-payload) is sent to the Webhook/Kafka topic:
+The following [action invocation body](../../self-service-actions/self-service-actions-deep-dive/self-service-actions-deep-dive.md#self-service-action-run-payload) is sent to the Webhook/Kafka topic:
 
 ```json showLineNumbers
 {


### PR DESCRIPTION
make action runs tutorial a subpage of deep dive

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
