### PR TITLE
Port 3367 k 8 s exporter add create missing related entities and verbosity arguments

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/api/advanced.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/api/advanced.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 2
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import DeleteDependents from '../../../generalTemplates/\_delete_dependents_kubernetes_explanation_template.md'
+import CreateMissingRelatedEntities from '../../../generalTemplates/\_create_missing_related_entities_api_explanation_template.md'
+
+# Advanced
+
+The following advanced query parameters are available:
+
+<Tabs groupId="advanced" queryString="current-config-param" defaultValue="delete_dependents" values={[
+{label: "Delete Dependents", value: "delete_dependents"},
+{label: "Create Missing Related Entities", value: "create_missing_related_entities"},
+]} >
+
+<TabItem value="delete_dependents">
+
+<DeleteDependents/>
+
+- Default: `false` (disabled)
+- Use case: Deletion of dependent Port entities. Must be enabled, if you want to delete a target entity (and its source entities) in a required relation.
+- Available at `DELETE` API endpoint of a specific entity.
+
+</TabItem>
+
+<TabItem value="create_missing_related_entities">
+
+<CreateMissingRelatedEntities/>
+
+- Default: `false` (disabled)
+- Use case: Creation of missing related Port entities. Must be enabled, if you want to create a source entity (and the target entity) even though the target entity doesn't exist.
+- Available at `POST`, `PUT`, `PATCH` API endpoints of a specific entity.
+
+</TabItem>
+
+</Tabs>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/api/api.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/api/api.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # API
 
 import FindCredentials from "./\_template_docs/\_find_credentials.mdx";

--- a/docs/build-your-software-catalog/sync-data-to-catalog/kubernetes/advanced.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/kubernetes/advanced.md
@@ -5,6 +5,7 @@ sidebar_position: 4
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import DeleteDependents from '../../../generalTemplates/\_delete_dependents_kubernetes_explanation_template.md'
+import CreateMissingRelatedEntities from '../../../generalTemplates/\_create_missing_related_entities_kubernetes_explanation_template.md'
 
 # Advanced
 
@@ -28,6 +29,8 @@ The following advanced configuration parameters are available:
 {label: "Resync Interval", value: "resyncInterval"},
 {label: "State Key", value: "stateKey"},
 {label: "Delete Dependents", value: "deleteDependents"},
+{label: "Create Missing Related Entities", value: "createMissingRelatedEntities"},
+{label: "Verbosity (Level)", value: "verbosity"},
 ]} >
 
 <TabItem value="resyncInterval">
@@ -57,6 +60,26 @@ The `stateKey` parameter specifies a unique state key per K8s exporter installat
 
 - Default: `false` (disabled)
 - Use case: Deletion of dependent Port entities. Must be enabled, if you want to delete a target entity (and its source entities) in a required relation.
+
+</TabItem>
+
+<TabItem value="createMissingRelatedEntities">
+
+<CreateMissingRelatedEntities/>
+
+- Default: `false` (disabled)
+- Use case: Creation of missing related Port entities. For example:
+  - Creation of related entity that has no matching resource kind in K8s, like `cluster`.
+  - Creation of an entity and its related entity, even though the related entity doesn't exist yet in Port.
+
+</TabItem>
+
+<TabItem value="verbosity">
+
+The `verbosity` parameter is used to control the verbosity level of info logs in K8s exporter pod.
+
+- Default: `0` (show all info and error logs, including info logs of successful updates)
+- Use case: Clear out info logs of successful updates (set the value to `-1`).
 
 </TabItem>
 

--- a/docs/generalTemplates/_create_missing_related_entities_api_explanation_template.md
+++ b/docs/generalTemplates/_create_missing_related_entities_api_explanation_template.md
@@ -1,0 +1,1 @@
+The `create_missing_related_entities` parameter is used to enable creation of missing related Port entities. This is useful when you want to create an entity and its related entity in one call, or you want to create an entity which is related entity doesn't exist yet.

--- a/docs/generalTemplates/_create_missing_related_entities_kubernetes_explanation_template.md
+++ b/docs/generalTemplates/_create_missing_related_entities_kubernetes_explanation_template.md
@@ -1,0 +1,1 @@
+The `createMissingRelatedEntities` parameter is used to enable creation of missing related Port entities.

--- a/docs/generalTemplates/_delete_dependents_api_explanation_template.md
+++ b/docs/generalTemplates/_delete_dependents_api_explanation_template.md
@@ -1,0 +1,1 @@
+The `delete_dependents` query parameter is used to enable deletion of dependent Port entities. This is useful when you have two blueprints with a required relation, and the target entity in the relation should be deleted. In this scenario, the delete operation will fail if this flag is set to `false` if the flag is set to `true`, the source entity will be deleted as well.


### PR DESCRIPTION
# Description

Add advanced to API, create missing related entities and verbosity arguments to K8s advanced.

## Added docs pages

## Updated docs pages

- API Advanced (`/build-your-software-catalog/sync-data-to-catalog/api/advanced.md`)
- K8s Advanced (`/build-your-software-catalog/sync-data-to-catalog/kubernetes/advanced.md`)
