### PR TITLE
Samuel sentry

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/sentry/_example_sentry_issue_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/sentry/_example_sentry_issue_blueprint.mdx
@@ -1,0 +1,41 @@
+```json showLineNumbers
+{
+  "identifier": "sentryIssues",
+  "description": "The purpose of these Blueprints is to demonstrate how to map Sentry Webhooks Issues to the Port Platform.",
+  "title": "Sentry Issues",
+  "icon": "Sentry",
+  "schema": {
+    "properties": {
+      "action": {
+        "type": "string",
+        "title": "This can be created, resolved, assigned, or ignored",
+        "enum": ["created", "resolved", "assigned", "ignored"]
+      },
+      "issue": {
+        "type": "object",
+        "title": "The Issue"
+      },
+      "issueUrl": {
+        "type": "string",
+        "title": "Issue_Url",
+        "format": "url"
+      },
+      "webUrl": {
+        "type": "string",
+        "title": "Web Url",
+        "description": "the web url for the issue",
+        "format": "url"
+      },
+      "projectUrl": {
+        "type": "string",
+        "format": "url",
+        "title": "Project URL"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "relations": {}
+}
+```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/sentry/_example_sentry_issue_configuration.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/sentry/_example_sentry_issue_configuration.mdx
@@ -1,0 +1,32 @@
+```json showLineNumbers
+{
+  "identifier": "sentryMapper",
+  "title": "Sentry mapper",
+  "description": "The purpose of these Blueprints is to demonstrate how to map Sentry Webhooks Issues to the Port Platform.",
+  "icon": "Sentry",
+  "mappings": [
+    {
+      "blueprint": "sentryIssues",
+      "entity": {
+        "identifier": ".body.data.issue.id",
+        "title": ".body.data.issues.title",
+        "properties": {
+          "action": ".body.action",
+          "issue": ".body.data.issue",
+          "issueUrl": ".body.data.issue.url",
+          "webUrl": ".body.data.issue.web_url",
+          "projectUrl": ".body.data.issue.project_url"
+        }
+      }
+    }
+  ],
+  "enabled": true,
+  "security": {
+    "secret": "WEBHOOK_SECRET",
+    "signatureHeaderName": "sentry-hook-signature",
+    "signatureAlgorithm": "sha256",
+    "signaturePrefix":""
+
+  }
+}
+```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/sentry.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/sentry.md
@@ -1,0 +1,47 @@
+---
+sidebar_position: 6
+description: Ingest Sentry issue events into your catalog
+---
+
+import SentryIssueBlueprint from './resources/sentry/\_example_sentry_issue_blueprint.mdx'
+import SentryIssueWebhookConfig from './resources/sentry/\_example_sentry_issue_configuration.mdx'
+
+# Sentry
+
+In this example you are going to create a webhook integration between [Sentry](https://sentry.io) and Port, which will ingest issue events and comment entities.
+
+## Prerequisites
+
+Create the following blueprint definitions and webhook configuration:
+
+<details>
+<summary> Issue event blueprint </summary>
+
+<SentryIssueBlueprint/>
+
+</details>
+
+<details>
+<summary> Issue Sentry webhook configuration </summary>
+
+Remember to update the `WEBHOOK_SECRET` with the real secret Sentry generates after you create the webhook integration.
+
+<SentryIssueWebhookConfig/>
+
+</details>
+
+## Create the Sentry webhook
+
+1. Go to `https://{YOUR_SENTRY_ORGANIZATION-SLUG}.sentry.io/settings/developer-settings/`;
+2. You can select your exisitng Integration(Internal or Public integration) you can also Select **Create New Integration** to create a new Integration;
+3. Select **Internal Integration** and click **Next**;
+4. Input the following details:
+   1. `Name` - use a meaningful name such as Port Webhook;
+   2. `Webhook URL` - enter the value of the `url` key you received after creating the webhook configuration;
+   3. `Overview` - enter a description for the webhook;
+   4. `Permission` - Assign the right permission for this integration;
+   5. `Webhooks` - Tick the box for every Webhook you need.
+5.  Click on **Save Changes** (Click on your newly created Integration to see tokens and Client Secret)
+
+
+Done! any issues trigger in Sentry (created, resolved, assigned, ignored) will trigger a webhook event that Sentry wull send to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.


### PR DESCRIPTION
# Description

This changes shows how to connect Sentry webhook to send events to Port

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/port-docs/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/sentry.md`)
- Blueprint (`/port-docs/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/sentry/_example_sentry_issue_blueprint.mdx`)
- Configurations ('/port-docs/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/sentry/_example_sentry_issue_configuration.mdx')
