### PR TITLE
Update OpsGenie to include who is on call

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/opsgenie.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/opsgenie.md
@@ -55,7 +55,7 @@ Create the following blueprint definition and webhook configuration:
 Done! any change that happens to an OpsGenie alert (created, acknowledged, etc.) will trigger a webhook event that OpsGenie will send to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.
 
 ## Ingest who is on-call
-In this example we will create a blueprint for `service` entities with a `on-call` property that will be ingested directly from OpsGenie. 
-The exmaples below are pulling data from the OpsGenie REST Api, in a defined scheduled period using GitLab Pipelines or GitHub Workflows, and reports the data to Port as a property to the `service` blueprint.
+In this example we will create a blueprint for `service` entities with an `on-call` property that will be ingested directly from OpsGenie. 
+The examples below pull data from the OpsGenie REST Api, in a defined scheduled period using GitLab Pipelines or GitHub Workflows, and report the data to Port as a property to the `service` blueprint.
 - [Github Workflow](https://github.com/port-labs/opsgenie-oncall-example)
 - [GitLab CI Pipeline](https://gitlab.com/getport-labs/opsgenie-oncall-example)

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/opsgenie.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/opsgenie.md
@@ -53,3 +53,8 @@ Create the following blueprint definition and webhook configuration:
 7. Click **Save integration**
 
 Done! any change that happens to an OpsGenie alert (created, acknowledged, etc.) will trigger a webhook event that OpsGenie will send to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.
+
+## Ingest who is on-call
+In this example you will create a blueprint for `service` entity that ingests who is on call data from OpsGenie using REST API. Then you will add some Python code to create new entities in Port every time a Github Action or GitLab Pipeline is triggered by a schedule. The links below guide you on how to accomplish this task on your preferred environment.
+[Github Action](https://github.com/PeyGis/OpsGenie)
+[GitLab CI Pipeline](https://gitlab.com/pages_coffy/opsgenie_port)

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/opsgenie.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/opsgenie.md
@@ -55,6 +55,6 @@ Create the following blueprint definition and webhook configuration:
 Done! any change that happens to an OpsGenie alert (created, acknowledged, etc.) will trigger a webhook event that OpsGenie will send to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.
 
 ## Ingest who is on-call
-In this example you will create a blueprint for `service` entity that ingests who is on call data from OpsGenie using REST API. Then you will add some Python code to create new entities in Port every time a Github Action or GitLab Pipeline is triggered by a schedule. The links below guide you on how to accomplish this task on your preferred environment.
-[Github Action](https://github.com/PeyGis/OpsGenie)
-[GitLab CI Pipeline](https://gitlab.com/pages_coffy/opsgenie_port)
+In this example you will create a blueprint for `service` entity that ingests who is on call data from OpsGenie using REST API. Then you will add some Python code to create new entities in Port every time a Github Workflow or GitLab Pipeline is triggered by a schedule. The links below guide you on how to accomplish this task on your preferred environment.
+[Github Workflow](https://github.com/port-labs/opsgenie-oncall-example)
+[GitLab CI Pipeline](https://gitlab.com/getport-labs/opsgenie-oncall-example)

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/opsgenie.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/opsgenie.md
@@ -55,6 +55,7 @@ Create the following blueprint definition and webhook configuration:
 Done! any change that happens to an OpsGenie alert (created, acknowledged, etc.) will trigger a webhook event that OpsGenie will send to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.
 
 ## Ingest who is on-call
-In this example you will create a blueprint for `service` entity that ingests who is on call data from OpsGenie using REST API. Then you will add some Python code to create new entities in Port every time a Github Workflow or GitLab Pipeline is triggered by a schedule. The links below guide you on how to accomplish this task on your preferred environment.
-[Github Workflow](https://github.com/port-labs/opsgenie-oncall-example)
-[GitLab CI Pipeline](https://gitlab.com/getport-labs/opsgenie-oncall-example)
+In this example we will create a blueprint for `service` entities with a `on-call` property that will be ingested directly from OpsGenie. 
+The exmaples below are pulling data from the OpsGenie REST Api, in a defined scheduled period using GitLab Pipelines or GitHub Workflows, and reports the data to Port as a property to the `service` blueprint.
+- [Github Workflow](https://github.com/port-labs/opsgenie-oncall-example)
+- [GitLab CI Pipeline](https://gitlab.com/getport-labs/opsgenie-oncall-example)


### PR DESCRIPTION
# Description

This PR adds a section that points users on how to ingest OpsGenie's on-call data into Port

## Updated docs pages

https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/webhook/examples/opsgenie