### PR TITLE
remove region from aws examples

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/aws/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/aws/examples.md
@@ -354,9 +354,6 @@ In this step-by-step example, you will export your `App Runner services` to Port
                    "serviceUrl": "\"https://\" + .ServiceUrl",
                    "iamRole": ".InstanceConfiguration.InstanceRoleArn | if . == null then null else \"https://console.aws.amazon.com/go/view?arn=\" + . end",
                    "arn": ".ServiceArn"
-                 },
-                 "relations": {
-                   "region": ".ServiceArn | split(\":\")[3]"
                  }
                }
              ]
@@ -814,9 +811,6 @@ In this step-by-step example, you will export your `SNS topics` and `SQS queues`
                    "delaySeconds": ".DelaySeconds",
                    "tags": ".Tags",
                    "arn": ".Arn"
-                 },
-                 "relations": {
-                   "region": ".Arn | split(\":\")[3]"
                  }
                }
              ]


### PR DESCRIPTION
# Description

Remove region relation from aws examples

## Updated docs pages

Please also include the path for the updated docs

- AWS Examples (`/build-your-software-catalog/sync-data-to-catalog/aws/examples.md`)
