### PR TITLE
Update Datadog Webhook Documentation

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/datadog.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/datadog.md
@@ -13,7 +13,7 @@ In this example you are going to create a webhook integration between [Datadog](
 
 ## Prerequisites
 
-Create the following blueprint definitions and webhook configuration:
+Create the following blueprint definitions:
 
 <details>
 <summary>Datadog microservice blueprint</summary>
@@ -25,9 +25,23 @@ Create the following blueprint definitions and webhook configuration:
 <DatadogBlueprint/>
 </details>
 
+Create the following webhook configuration [using Port UI](../../?operation=ui#configuring-webhook-endpoints)
+
 <details>
 <summary>Datadog webhook configuration</summary>
+
+1. Basic details:
+   1. Title : `Datadog Alert Mapper`;
+   2. Identifier : `datadog_alert_mapper`;
+   3. Description : `A webhook configuration for alerts/monitors events from Datadog`;
+   4. Icon : `Datadog`;
+2. Integration configuration:
+   1. The JQ mapping;
+
 <DatadogConfiguration/>
+
+3.  Click **Save** at the bottom of the page.
+
 </details>
 
 :::note

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/datadog/_example_datadog_webhook_configuration.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/datadog/_example_datadog_webhook_configuration.mdx
@@ -1,31 +1,24 @@
 ```json showLineNumbers
-{
-  "identifier": "datadogAlertMapper",
-  "title": "Alert Mapper",
-  "description": "A webhook configuration for alerts/monitors events from Datadog",
-  "icon": "Datadog",
-  "mappings": [
-    {
-      "blueprint": "datadogAlert",
-      "entity": {
-        "identifier": ".body.alert_id | tostring",
-        "title": ".body.title",
-        "properties": {
-          "url": ".body.event_url",
-          "message": ".body.message",
-          "eventType": ".body.event_type",
-          "priority": ".body.priority",
-          "creator": ".body.creator",
-          "alertMetric": ".body.alert_metric",
-          "alertType": ".body.alert_type",
-          "tags": ".body.tags | split(\", \")"
-        },
-        "relations": {
-          "microservice": ".body.service"
-        }
+[
+  {
+    "blueprint": "datadogAlert",
+    "entity": {
+      "identifier": ".body.alert_id | tostring",
+      "title": ".body.title",
+      "properties": {
+        "url": ".body.event_url",
+        "message": ".body.message",
+        "eventType": ".body.event_type",
+        "priority": ".body.priority",
+        "creator": ".body.creator",
+        "alertMetric": ".body.alert_metric",
+        "alertType": ".body.alert_type",
+        "tags": ".body.tags | split(\", \")"
+      },
+      "relations": {
+        "microservice": ".body.service"
       }
     }
-  ],
-  "security": {}
-}
+  }
+]
 ```


### PR DESCRIPTION
# Description

Modify the documentation to show how to configure webhook using Port UI.

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/datadog.md`)
- Webhook (`/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/datadog/_example_datadog_webhook_configuration.mdx`)
- ...
