### PR TITLE
Add New Relic Alerts to Port

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/newrelic.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/newrelic.md
@@ -6,6 +6,8 @@ description: Ingest New Relic alerts into your catalog
 import NewRelicAlertBlueprint from "./resources/newrelic/\_example_alert_blueprint.mdx";
 import NewRelicWebhookConfiguration from "./resources/newrelic/\_example_alert_webhook_config.mdx"
 import MicroserviceBlueprint from "./resources/newrelic/\_example_microservice_blueprint.mdx"
+import NewRelicserviceBlueprint from "./resources/newrelic/\_example_newrelic_service_blueprint.mdx"
+import PythonScript from "./resources/newrelic/\_example_python_script.mdx"
 
 # New Relic
 
@@ -143,3 +145,21 @@ The combination of the sample payload and the webhook configuration generate the
   }
 }
 ```
+
+## Ingest services and applications from your APM
+
+In this example, you will create a `newRelicService` blueprint that ingests all services and applications in your New Relic APM using REST API. You will then add some python script to create new entities in Port.
+
+<details>
+<summary>New Relic service blueprint</summary>
+<NewRelicserviceBlueprint/>
+</details>
+
+<details>
+<summary>Python script</summary>
+<PythonScript/>
+</details>
+
+:::note
+Please note that by deafult, all New Relic REST API clients are configured to consume New Relic US site APIs (https://api.newrelic.com/v2). If you are on the New Relic EU site, set the environment variable `NEW_RELIC_API_URL` to https://api.eu.newrelic.com/v2.
+:::

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/newrelic.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/newrelic.md
@@ -1,0 +1,145 @@
+---
+sidebar_position: 13
+description: Ingest New Relic alerts into your catalog
+---
+
+import NewRelicAlertBlueprint from "./resources/newrelic/\_example_alert_blueprint.mdx";
+import NewRelicWebhookConfiguration from "./resources/newrelic/\_example_alert_webhook_config.mdx"
+import MicroserviceBlueprint from "./resources/newrelic/\_example_microservice_blueprint.mdx"
+
+# New Relic
+
+In this example you are going to create a webhook integration between [New Relic](https://newrelic.com/) and Port, which will ingest alerts entities to Port and map them to your microservice entities.
+
+## Prerequisites
+
+Create the following blueprint definitions and webhook configuration:
+
+<details>
+<summary>Microservice blueprint</summary>
+<MicroserviceBlueprint/>
+</details>
+
+<details>
+<summary>New Relic alert blueprint</summary>
+<NewRelicAlertBlueprint/>
+</details>
+
+<details>
+<summary>New Relic webhook configuration</summary>
+<NewRelicWebhookConfiguration/>
+</details>
+
+:::note
+The webhook configuration's relation mapping will function properly only when the identifiers of the Port microservice entities match the names of the services or hosts in your New Relic.
+:::
+
+## Create the New Relic webhook
+
+Creating alert notifications in New Relic can be achieved in 2 stages: setting up the webhook destination and configuring workflows.
+
+### Set up webhook destination
+
+1. Log in to New Relic with your credentials;
+2. Click on **Alerts and AI** at the left sidebar of the page;
+3. Go to **Destinations**;
+4. Under **Add a destination** page, click on **Webhook** and follow the setup instructions;
+5. Input the following details:
+   1. `Webhook name` - use a meaningful name such as Port_Webhook;
+   2. `Endpoint URL` - enter the value of the `url` key you received after [creating the webhook configuration](../webhook.md#configuring-webhook-endpoints);
+6. Click **Save** at the bottom of the page to save your webhook destination.
+
+### Configure your workflow
+
+1. Log in to New Relic with your credentials;
+2. Click on **Alerts and AI** at the left sidebar of the page;
+3. Go to **Workflows** and click on **Add a workflow**;
+4. Input the following details:
+   1. `Workflow name` - Enter a descriptive name for your workflow;
+   2. `Filter data` - Select the kind of issues you want to send or leave it empty to send all issues to your webhook destination;
+5. Under the **Notify** section, click on **Webhook** to open the notification message window;
+6. Input the following details:
+   1. `Destination` - Select the [webhook destination](#set-up-webhook-destination) you created above from the dropdown list;
+   2. `Payload` - When an alert is triggered on your workflow, this payload will be sent to the webhook URL. Enter this JSON placeholder in the textbox;
+      ```json showLineNumbers
+      {
+        "id": {{ json issueId }},
+        "issueUrl": {{ json issuePageUrl }},
+        "title": {{ json annotations.title.[0] }},
+        "priority": {{ json priority }},
+        "impactedEntities": {{json entitiesData.names}},
+        "state": {{ json state }},
+        "trigger": {{ json triggerEvent }},
+        "createdAt": {{ createdAt }},
+        "updatedAt": {{ updatedAt }},
+        "sources": {{ json accumulations.source }},
+        "alertPolicyNames": {{ json accumulations.policyName }},
+        "alertConditionNames": {{ json accumulations.conditionName }},
+        "workflowName": {{ json workflowName }},
+         "tags": {{ json accumulations.tag.affectedService }}
+      }
+      ```
+   3. `Custom headers` - configure any custom HTTP header to be added to the webhook event;
+7. Click **Save message** at the bottom of the page to save your notification workflow.
+   :::tip
+   In order to view the different payloads and structure of the events in New Relic webhooks, [look here](https://docs.newrelic.com/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows/)
+   :::
+
+Done! any problem detected on your New Relic account will trigger a webhook event. Port will parse the events according to the mapping and update the catalog entities accordingly.
+
+## Test the webhook
+
+This section includes a sample webhook event sent from New Relic when an alert is triggered. In addition, it also includes the entity created from the event based on the webhook configuration provided in the previous section.
+
+### Payload
+
+Here is an example of the payload structure sent to the webhook URL when an alert is created:
+
+<details>
+<summary> Webhook event payload</summary>
+
+```json showLineNumbers
+{
+  "id": "d1b1f3fd-995a-4066-88ab-8ce4f6960623",
+  "issueUrl": "https://radar-api.service.newrelic.com/accounts/1/issues/0ea2df1c-adab-45d2-aae0-042b609d2322?notifier=SLACK",
+  "title": "Memory Used % > 90 for at least 2 minutes on 'Some-Entity'",
+  "priority": "CRITICAL",
+  "impactedEntities": ["logs-itg-cloud", "MonitorTTFB-query"],
+  "state": "ACTIVATED",
+  "trigger": "INCIDENT_ADDED",
+  "createdAt": 1617881246260,
+  "updatedAt": 1617881246260,
+  "sources": ["newrelic"],
+  "alertPolicyNames": ["Policy1", "Policy2"],
+  "alertConditionNames": ["condition1", "condition2"],
+  "workflowName": "DBA Team workflow",
+  "tags": ["service-1", "service-2"]
+}
+```
+
+</details>
+
+### Mapping Result
+
+The combination of the sample payload and the webhook configuration generate the following Port entity:
+
+```json showLineNumbers
+{
+  "identifier": "d1b1f3fd-995a-4066-88ab-8ce4f6960623",
+  "title": "Memory Used % > 90 for at least 2 minutes on 'Some-Entity'",
+  "blueprint": "newRelicAlert",
+  "properties": {
+    "priority": "CRITICAL",
+    "issueURL": "https://radar-api.service.newrelic.com/accounts/1/issues/0ea2df1c-adab-45d2-aae0-042b609d2322?notifier=SLACK",
+    "state": "ACTIVATED",
+    "trigger": "INCIDENT_ADDED",
+    "sources": ["newrelic"],
+    "workflowName": "DBA Team workflow",
+    "alertConditionNames": ["condition1", "condition2"],
+    "alertPolicyNames": ["Policy1", "Policy2"]
+  },
+  "relations": {
+    "microservice": ["service-1", "service-2"]
+  }
+}
+```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/_example_alert_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/_example_alert_blueprint.mdx
@@ -1,0 +1,69 @@
+```json showLineNumbers
+{
+  "identifier": "newRelicAlert",
+  "description": "This blueprint represents a New Relic alert in our software catalog",
+  "title": "New Relic Alert",
+  "icon": "NewRelic",
+  "schema": {
+    "properties": {
+      "priority": {
+        "type": "string",
+        "title": "Priority",
+        "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+        "enumColors": {
+          "CRITICAL": "red",
+          "HIGH": "red",
+          "MEDIUM": "yellow",
+          "LOW": "green"
+        }
+      },
+      "issueURL": {
+        "type": "string",
+        "format": "url",
+        "title": "Issue URL"
+      },
+      "state": {
+        "type": "string",
+        "title": "State",
+        "enum": ["ACTIVATED", "CLOSED", "CREATED"],
+        "enumColors": {
+          "ACTIVATED": "yellow",
+          "CLOSED": "green",
+          "CREATED": "lightGray"
+        }
+      },
+      "trigger": {
+        "type": "string",
+        "title": "Trigger"
+      },
+      "sources": {
+        "type": "array",
+        "title": "Sources"
+      },
+      "workflowName": {
+        "title": "Workflow Name",
+        "type": "string"
+      },
+      "alertConditionNames": {
+        "type": "array",
+        "title": "Alert Condition Names"
+      },
+      "alertPolicyNames": {
+        "type": "array",
+        "title": "Alert Policy Names"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "relations": {
+    "microservice": {
+      "title": "Microservice",
+      "target": "microservice",
+      "required": false,
+      "many": true
+    }
+  }
+}
+```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/_example_alert_webhook_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/_example_alert_webhook_config.mdx
@@ -1,0 +1,32 @@
+```json showLineNumbers
+{
+  "identifier": "newRelicAlertMapper",
+  "title": "Alert Mapper",
+  "description": "A webhook configuration for alerts events from New Relic",
+  "icon": "NewRelic",
+  "mappings": [
+    {
+      "blueprint": "newRelicAlert",
+      "filter": "true",
+      "entity": {
+        "identifier": ".body.id",
+        "title": ".body.title",
+        "properties": {
+          "priority": ".body.priority",
+          "issueURL": ".body.issueUrl",
+          "state": ".body.state",
+          "trigger": ".body.trigger",
+          "sources": ".body.sources",
+          "workflowName": ".body.workflowName",
+          "alertConditionNames": ".body.alertConditionNames",
+          "alertPolicyNames": ".body.alertPolicyNames"
+        },
+        "relations": {
+          "microservice": ".body.tags"
+        }
+      }
+    }
+  ],
+  "security": {}
+}
+```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/_example_microservice_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/_example_microservice_blueprint.mdx
@@ -1,0 +1,19 @@
+```json showLineNumbers
+{
+  "identifier": "microservice",
+  "title": "Microservice",
+  "icon": "Microservice",
+  "schema": {
+    "properties": {
+      "description": {
+        "title": "Description",
+        "type": "string"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "relations": {}
+}
+```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/_example_newrelic_service_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/_example_newrelic_service_blueprint.mdx
@@ -1,0 +1,44 @@
+```json showLineNumbers
+{
+  "identifier": "newRelicService",
+  "description": "This blueprint represents a New Relic service or application in our software catalog",
+  "title": "New Relic Service",
+  "icon": "NewRelic",
+  "schema": {
+    "properties": {
+      "language": {
+        "type": "string",
+        "title": "Language"
+      },
+      "health_status": {
+        "type": "string",
+        "title": "Health Status",
+        "enum": ["green", "orange", "gray", "unknown", "red"],
+        "enumColors": {
+          "orange": "orange",
+          "green": "green",
+          "gray": "lightGray",
+          "unknown": "purple",
+          "red": "red"
+        }
+      },
+      "application_summary": {
+        "type": "object",
+        "title": "Summary"
+      },
+      "settings": {
+        "type": "object",
+        "title": "Settings"
+      },
+      "links": {
+        "type": "object",
+        "title": "Links"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "relations": {}
+}
+```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/_example_python_script.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/_example_python_script.mdx
@@ -1,0 +1,65 @@
+```python showLineNumbers
+## Import the needed libraries
+import requests
+import os
+
+
+# Get environment variables using the config object or os.environ["KEY"]
+PORT_CLIENT_ID = os.environ['PORT_CLIENT_ID']
+PORT_CLIENT_SECRET = os.environ['PORT_CLIENT_SECRET']
+PORT_API_URL = "https://api.getport.io/v1"
+NEW_RELIC_API_URL = os.environ["NEW_RELIC_API_URL"]
+NEW_RELIC_API_KEY = os.environ["NEW_RELIC_API_KEY"]
+
+
+## Get Port Access Token
+credentials = {'clientId': PORT_CLIENT_ID, 'clientSecret': PORT_CLIENT_SECRET}
+token_response = requests.post(f'{PORT_API_URL}/auth/access_token', json=credentials)
+access_token = token_response.json()['accessToken']
+
+# You can now use the value in access_token when making further requests
+headers = {
+	'Authorization': f'Bearer {access_token}'
+}
+blueprint_id = 'newRelicService'
+
+
+def add_entity_to_port(entity_object):
+    """A function to create the passed entity in Port
+
+    Params
+    --------------
+    entity_object: dict
+        The entity to add in your Port catalog
+
+    Returns
+    --------------
+    response: dict
+        The response object after calling the webhook
+    """
+    response = requests.post(f'{PORT_API_URL}/blueprints/{blueprint_id}/entities?upsert=true&merge=true', json=entity_object, headers=headers)
+    print(response.json())
+
+
+def retrieve_new_relic_services():
+    """A function to make API request to New Relic to retrieve Applications and Services"""
+
+    new_relic_headers = {'X-Api-Key': f'{NEW_RELIC_API_KEY}', 'Accept': 'application/json'}
+    api_response = requests.get(f'{NEW_RELIC_API_URL}/applications.json', headers=new_relic_headers)
+    services = api_response.json()["applications"]
+    for service in services:
+        entity = {
+            "identifier": str(service['id']),
+            "title": service["name"],
+            "properties": {
+                "language": service["language"],
+                "health_status": service["health_status"],
+                "application_summary": service["application_summary"],
+                "settings": service["settings"],
+                "links": service["links"]
+            },
+            "relations": {}
+            }
+        add_entity_to_port(entity)
+retrieve_new_relic_services()
+```


### PR DESCRIPTION
# Description

Configured New Relic to send issue alerts to Port using Webhook

## Added docs pages

 docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/newrelic.md
 docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/newrelic/

