### PR TITLE
Update sonarqube webhook request header

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/sonarqube.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/sonarqube.md
@@ -47,7 +47,7 @@ Create the following webhook configuration [using Port ui](../../?operation=ui#c
 3. Scroll down to **Advanced settings** and input the following details:
 
    1. secret: `WEBHOOK_SECRET`;
-   2. Signature Header Name : `X-Sonar-Webhook-HMAC-SHA256`;
+   2. Signature Header Name : `x-sonar-webhook-hmac-sha256`;
    3. Signature Algorithm : Select `sha256` from dropdown option;
    4. Click **Save** at the bottom of the page.
 


### PR DESCRIPTION
# Description

Clients were unable to ingest Sonarqube cloud analysis into Port due to differences (case sensitivity) in the Sonarqube webhook request header signature field


## Updated docs pages

docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/sonarqube.md