### PR TITLE
PORT-5159-remove-all-mentions-of-fernet-in-docs-other-than-the-depracated-part

### DIFF
--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/create-github-secret.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/create-github-secret.md
@@ -77,7 +77,7 @@ Make sure to replace the placeholders for GITHUB_ORG_NAME, GITHUB_REPO_NAME and 
           "icon": "DefaultProperty",
           "title": "Secret Value",
           "type": "string",
-          "encryption": "fernet"
+          "encryption": "aes256-gcm"
         }
       },
       "required": ["secret_key", "secret_value"],

--- a/docs/create-self-service-experiences/setup-ui-for-action/user-inputs/secret.md
+++ b/docs/create-self-service-experiences/setup-ui-for-action/user-inputs/secret.md
@@ -59,7 +59,7 @@ A secret input is defined as a regular input, but with the additional `encryptio
     // highlight-start
     "type": "string",
     // highlight-end
-    "encryption": "fernet",
+    "encryption": "aes256-gcm",
     "description": "My entity input"
   }
 }
@@ -78,7 +78,7 @@ A secret input is defined as a regular input, but with the additional `encryptio
     // highlight-start
     "type": "object",
     // highlight-end
-    "encryption": "fernet",
+    "encryption": "aes256-gcm",
     "description": "My entity input"
   }
 }


### PR DESCRIPTION
just switched the secret property examples from fernet to the newer (and not depracated aes256-gcm)
