### PR TITLE
Update create-github-secret.md

### DIFF
--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/create-github-secret.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/create-github-secret.md
@@ -14,7 +14,7 @@ Follow these steps to get started:
 
 1. Create the following GitHub Action secrets:
 
-   1. `PERSONAL_ACCESS_TOKEN` - a [Classic Personal Access Token](hhttps://github.com/settings/tokens) with the following scopes:
+   1. `PERSONAL_ACCESS_TOKEN` - a [Classic Personal Access Token](https://github.com/settings/tokens) with the following scopes:
 
       ![Token Scopes](../../../../../static/img/self-service-actions/setup-backend/github-workflow/pat-scopes.png)
 


### PR DESCRIPTION
# Description

Fixed a typo in github tokens link

## Updated docs pages

Please also include the path for the updated docs

- Github Secret (`/create-self-service-experiences/setup-backend/github-workflow/examples/create-github-secret`
