### PR TITLE
[Integration][NewRelic] Update the `--set-string` to `--set`

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
@@ -69,7 +69,7 @@ helm upgrade --install my-newrelic-integration port-labs/port-ocean \
 	--set integration.type="newrelic"  \
 	--set integration.eventListener.type="POLLING"  \
 	--set integration.secrets.newRelicAPIKey="<NR_API_KEY>"  \
-	--set-string integration.secrets.newRelicAccountID=<NR_ACCOUNT_ID>
+	--set integration.secrets.newRelicAccountID="<NR_ACCOUNT_ID>"
 ```
 
 </TabItem>


### PR DESCRIPTION
After https://github.com/port-labs/helm-charts/pull/49 is merged we can merge this, as we no longer need to pass it as `--set-string` as it will be handled in the helm chart