### PR TITLE
Jenkins Webhook - todate timestamp

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/jenkins/_example_jenkins_build_webhook_configuration.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/resources/jenkins/_example_jenkins_build_webhook_configuration.mdx
@@ -24,7 +24,7 @@
         "buildStatus": ".body.data.result",
         "buildUrl": ".body.url",
         "buildDuration": ".body.data.duration",
-        "timestamp": ".body.data.timestamp"
+        "timestamp": ".body.data.timestamp / 1000 | todate"
       },
       "relations": {
         "jenkinsJob": ".body.source | tostring | sub(\"%20\"; \"-\"; \"g\") | sub(\"/\"; \"-\"; \"g\") | .[:-1]"


### PR DESCRIPTION
https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/webhook/examples/jenkins

The timestamp is UNIX and it needs to be divided by 1000 and then map to date, otherwise it starts to fail