### PR TITLE
re-organzied port-agent and added argocd installation method

### DIFF
--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/_category_.json
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Installation Methods",
+  "position": 1
+}

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/argocd.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/argocd.md
@@ -1,0 +1,74 @@
+---
+sidebar_position: 2
+---
+
+# ArgoCD
+
+Let's dive in to a walkthrough on how to install the Port execution agent in your Kubernetes cluster.
+
+:::info
+You can observe the helm chart with the full installation [here](https://github.com/port-labs/helm-charts/tree/main/charts/port-agent).
+:::
+
+:::note prerequisites
+
+- [ArgoCD](https://argoproj.github.io/cd/) must be installed in your Kubernetes cluster. Please refer to
+  ArgoCD's [documentation](https://argo-cd.readthedocs.io/en/stable/) for further details on the installation;
+- The connection credentials to Kafka are provided to you by Port.
+- If you want to trigger a GitLab Pipeline, you need to have a [GitLab trigger token](https://docs.gitlab.com/ee/ci/triggers/)
+
+:::
+
+
+## Installation
+
+Install the `my-port-agent` ArgoCD Application by using the following yaml:
+:::note
+Remember to replace the placeholders for `YOUR_ORG_ID`, `YOUR_KAFKA_CONSUMER_GROUP`, `YOUR_PORT_CLIENT_ID` and `YOUR_PORT_CLIENT_SECRET`.
+:::
+
+<details>
+  <summary>ArgoCD Application</summary>
+
+```yaml showLineNumbers
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-port-agent
+spec:
+  destination:
+    name: ''
+    namespace: my-port-agent
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: ''
+    repoURL: 'https://port-labs.github.io/helm-charts'
+    targetRevision: 0.7.2
+    chart: port-agent
+    helm:
+      parameters:
+        - name: env.normal.KAFKA_CONSUMER_GROUP_ID
+          value: YOUR_KAFKA_CONSUMER_GROUP
+        - name: env.normal.PORT_ORG_ID
+          value: YOUR_ORG_ID
+        - name: env.secret.PORT_CLIENT_ID
+          value: YOUR_PORT_CLIENT_ID
+        - name: env.secret.PORT_CLIENT_SECRET
+          value: YOUR_PORT_CLIENT_SECRET
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+```
+
+</details>
+<br/>
+
+
+## Next Steps
+
+- [Usage](/create-self-service-experiences/self-service-actions-deep-dive/self-service-actions-deep-dive.md) guide Set up a webhook.

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/argocd.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/argocd.md
@@ -4,16 +4,16 @@ sidebar_position: 2
 
 # ArgoCD
 
-Let's dive in to a walkthrough on how to install the Port execution agent in your Kubernetes cluster.
+This page will walk you through the installation of the Port execution agent in your Kubernetes cluster using ArgoCD, utilizing it's [Helm Capabilities](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/).
 
 :::info
-You can observe the helm chart with the full installation [here](https://github.com/port-labs/helm-charts/tree/main/charts/port-agent).
+You can observe the Helm chart and the available parameters [here](https://github.com/port-labs/helm-charts/tree/main/charts/port-agent).
 :::
 
 :::note prerequisites
 
-- [ArgoCD](https://argoproj.github.io/cd/) must be installed in your Kubernetes cluster. Please refer to
-  ArgoCD's [documentation](https://argo-cd.readthedocs.io/en/stable/) for further details on the installation;
+- [Helm](https://helm.sh) must be installed to use the chart. Please refer to the Helm [documentation](https://helm.sh/docs/intro/install/) for further details about the installation.
+- [ArgoCD](https://argoproj.github.io/cd/) must be installed in your Kubernetes cluster. Please refer to ArgoCD's [documentation](https://argo-cd.readthedocs.io/en/stable/getting_started/#1-install-argo-cd) for further details on the installation.
 - The connection credentials to Kafka are provided to you by Port.
 - If you want to trigger a GitLab Pipeline, you need to have a [GitLab trigger token](https://docs.gitlab.com/ee/ci/triggers/)
 
@@ -22,9 +22,27 @@ You can observe the helm chart with the full installation [here](https://github.
 
 ## Installation
 
-Install the `my-port-agent` ArgoCD Application by using the following yaml:
+1. Add Port's Helm repo by using the following command:
+
+```bash
+helm repo add port-labs https://port-labs.github.io/helm-charts
+helm repo update
+```
+
+You can then run `helm search repo port-labs` to see the charts.
+
+2. In your git repo, create a directory called `argocd` and changedir into it. Then pull the `port-agent` helm chart:
+ ```bash showLineNumbers
+mkdir argocd
+cd argocd
+helm pull port-labs/port-agent --untar
+```
+
+3. Commit the changes to your git repository.
+
+4. Install the `my-port-agent` ArgoCD Application by using the following yaml:
 :::note
-Remember to replace the placeholders for `YOUR_ORG_ID`, `YOUR_KAFKA_CONSUMER_GROUP`, `YOUR_PORT_CLIENT_ID` and `YOUR_PORT_CLIENT_SECRET`.
+Remember to replace the placeholders for `YOUR_ORG_ID`, `YOUR_KAFKA_CONSUMER_GROUP`, `YOUR_PORT_CLIENT_ID` `YOUR_PORT_CLIENT_SECRET` and `YOUR_GIT_REPO_URL`.
 :::
 
 <details>
@@ -35,16 +53,13 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: my-port-agent
+  namespace: argocd
 spec:
   destination:
-    name: ''
     namespace: my-port-agent
-    server: 'https://kubernetes.default.svc'
+    server: https://kubernetes.default.svc
+  project: default
   source:
-    path: ''
-    repoURL: 'https://port-labs.github.io/helm-charts'
-    targetRevision: 0.7.2
-    chart: port-agent
     helm:
       parameters:
         - name: env.normal.KAFKA_CONSUMER_GROUP_ID
@@ -55,14 +70,15 @@ spec:
           value: YOUR_PORT_CLIENT_ID
         - name: env.secret.PORT_CLIENT_SECRET
           value: YOUR_PORT_CLIENT_SECRET
-  sources: []
-  project: default
+    path: argocd/port-agent
+    repoURL: YOUR_GIT_REPO_URL
+    targetRevision: main
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
-      - CreateNamespace=true
+    - CreateNamespace=true
 ```
 
 </details>
@@ -71,4 +87,4 @@ spec:
 
 ## Next Steps
 
-- [Usage](/create-self-service-experiences/self-service-actions-deep-dive/self-service-actions-deep-dive.md) guide Set up a webhook.
+- Refer to the [usage guide](/create-self-service-experiences/setup-backend/webhook/port-execution-agent/usage.md) to set up a webhook.

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/helm.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/helm.md
@@ -4,33 +4,33 @@ sidebar_position: 1
 
 # Helm
 
-Let's dive in to a walkthrough on how to install the Port execution agent in your Kubernetes cluster.
+This page will walk you through the installation of the Port execution agent in your Kubernetes cluster using Helm.
 
 :::info
-You can observe the helm chart with the full installation [here](https://github.com/port-labs/helm-charts/tree/main/charts/port-agent).
+You can observe the helm chart and the available parameters [here](https://github.com/port-labs/helm-charts/tree/main/charts/port-agent).
 :::
 
 :::note prerequisites
 
-- The [Helm](https://helm.sh) must be installed to use the chart. Please refer to
-  the Helm's [documentation](https://helm.sh/docs) for further details on the installation;
+- [Helm](https://helm.sh) must be installed to use the chart. Please refer to the Helm [documentation](https://helm.sh/docs/intro/install/) for further details about the installation.
 - The connection credentials to Kafka are provided to you by Port.
 - If you want to trigger a GitLab Pipeline, you need to have a [GitLab trigger token](https://docs.gitlab.com/ee/ci/triggers/)
 
 :::
 
+## Installation
+
 1. Add Port's Helm repo by using the following command:
 
-```bash showLineNumbers
+```bash
 helm repo add port-labs https://port-labs.github.io/helm-charts
+helm repo update
 ```
 
-If you already added this repo earlier, run `helm repo update` to retrieve
-the latest versions of the charts. You can then run `helm search repo port-labs` to see the charts.
+You can then run `helm search repo port-labs` to see the charts.
 
 2. Install the `port-agent` chart by using the following command:
 
-## Installation
 
 :::note
 Remember to replace the placeholders for `YOUR_ORG_ID`, `YOUR_KAFKA_CONSUMER_GROUP`, `YOUR_PORT_CLIENT_ID` and `YOUR_PORT_CLIENT_SECRET`.
@@ -47,4 +47,4 @@ helm install my-port-agent port-labs/port-agent \
 
 ## Next Steps
 
-- [Usage](/create-self-service-experiences/self-service-actions-deep-dive/self-service-actions-deep-dive.md) guide Set up a webhook.
+- Refer to the [usage guide](/create-self-service-experiences/setup-backend/webhook/port-execution-agent/usage.md) to set up a webhook.

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/helm.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/helm.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 1
+---
+
+# Helm
+
+Let's dive in to a walkthrough on how to install the Port execution agent in your Kubernetes cluster.
+
+:::info
+You can observe the helm chart with the full installation [here](https://github.com/port-labs/helm-charts/tree/main/charts/port-agent).
+:::
+
+:::note prerequisites
+
+- The [Helm](https://helm.sh) must be installed to use the chart. Please refer to
+  the Helm's [documentation](https://helm.sh/docs) for further details on the installation;
+- The connection credentials to Kafka are provided to you by Port.
+- If you want to trigger a GitLab Pipeline, you need to have a [GitLab trigger token](https://docs.gitlab.com/ee/ci/triggers/)
+
+:::
+
+1. Add Port's Helm repo by using the following command:
+
+```bash showLineNumbers
+helm repo add port-labs https://port-labs.github.io/helm-charts
+```
+
+If you already added this repo earlier, run `helm repo update` to retrieve
+the latest versions of the charts. You can then run `helm search repo port-labs` to see the charts.
+
+2. Install the `port-agent` chart by using the following command:
+
+## Installation
+
+:::note
+Remember to replace the placeholders for `YOUR_ORG_ID`, `YOUR_KAFKA_CONSUMER_GROUP`, `YOUR_PORT_CLIENT_ID` and `YOUR_PORT_CLIENT_SECRET`.
+:::
+
+```bash showLineNumbers
+helm install my-port-agent port-labs/port-agent \
+    --create-namespace --namespace port-agent \
+    --set env.normal.PORT_ORG_ID=YOUR_ORG_ID \
+    --set env.normal.KAFKA_CONSUMER_GROUP_ID=YOUR_KAFKA_CONSUMER_GROUP \
+    --set env.secret.PORT_CLIENT_ID=YOUR_PORT_CLIENT_ID \
+    --set env.secret.PORT_CLIENT_SECRET=YOUR_PORT_CLIENT_SECRET
+```
+
+## Next Steps
+
+- [Usage](/create-self-service-experiences/self-service-actions-deep-dive/self-service-actions-deep-dive.md) guide Set up a webhook.

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/installation-methods.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/installation-methods.md
@@ -1,0 +1,3 @@
+# Installation Methods
+
+This guide provides two installation methods for deploying port-agent: Helm and ArgoCD.

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/installation-methods.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/installation-methods.md
@@ -1,3 +1,0 @@
-# Installation Methods
-
-This guide provides two installation methods for deploying port-agent: Helm and ArgoCD.

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/port-execution-agent.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/port-execution-agent.md
@@ -26,5 +26,5 @@ The data flow when using the Port execution agent is as follows:
 
 ## Next steps
 
-- [Explore How to install and use the agent](./Installation.md)
-- [Control the payload sent to your endpoint](./port-execution-agent.md)
+- [Explore How to install and use the agent](/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/installation-methods.md)
+- [Control the payload sent to your endpoint](/create-self-service-experiences/setup-backend/webhook/port-execution-agent/control-the-payload.md)

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/port-execution-agent.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/port-execution-agent.md
@@ -26,5 +26,5 @@ The data flow when using the Port execution agent is as follows:
 
 ## Next steps
 
-- [Explore How to install and use the agent](/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/installation-methods.md)
+- [Explore How to install and use the agent](/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/helm.md)
 - [Control the payload sent to your endpoint](/create-self-service-experiences/setup-backend/webhook/port-execution-agent/control-the-payload.md)

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/usage.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/usage.md
@@ -32,15 +32,6 @@ When a new invocation is detected, the agent will pull it from your Kafka topic 
 ![Port Execution Agent Logs](/img/self-service-actions/port-execution-agent/portAgentLogs.png)
 
 
-## Next Steps
-
-Follow one of the guides below:
-
-- [Self-Service Actions Deep Dive](/create-self-service-experiences/self-service-actions-deep-dive/self-service-actions-deep-dive.md) - Set up a blueprint and self-service actions.
-- [Changelog Listener](/create-self-service-experiences/setup-backend/webhook/examples/changelog-listener.md) - Create a blueprint with `changelogDestination` to listen and act on changes in the software catalog.
-- [GitLab Pipeline Trigger](/create-self-service-experiences/setup-backend/gitlab-pipeline/gitlab-pipeline.md) - Create an action that triggers GitLab Pipeline execution.
-
-
 ## Advanced configuration
 Some environments require special configuration when working with the Port agent. This includes working with self-signed certificates and/or proxies.
 
@@ -73,7 +64,7 @@ env:
 For example:
 ```sh showLineNumbers
 HTTP_PROXY=http://my-proxy.com:1111
-HTTS_PROXY=http://my-proxy.com:2222
+HTTPS_PROXY=http://my-proxy.com:2222
 ALL_PROXY=http://my-proxy.com:3333
 ```
 
@@ -102,3 +93,12 @@ REQUESTS_CA_BUNDLE=/path/to/cacert.pem
 ```
 
 This configuration directs the `requests` library to use the specified CA bundle for SSL/TLS certificate verification, overriding default system settings. It's useful for trusting self-signed certificates or certificates from a private CA.
+
+
+## Next Steps
+
+Follow one of the guides below:
+
+- [Self-Service Actions Deep Dive](/create-self-service-experiences/self-service-actions-deep-dive/self-service-actions-deep-dive.md) - Set up a blueprint and self-service actions.
+- [Changelog Listener](/create-self-service-experiences/setup-backend/webhook/examples/changelog-listener.md) - Create a blueprint with `changelogDestination` to listen and act on changes in the software catalog.
+- [GitLab Pipeline Trigger](/create-self-service-experiences/setup-backend/gitlab-pipeline/gitlab-pipeline.md) - Create an action that triggers GitLab Pipeline execution.

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/usage.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/usage.md
@@ -2,48 +2,7 @@
 sidebar_position: 2
 ---
 
-# Installation
-
-Let's dive in to a walkthrough on how to install the Port execution agent in your Kubernetes cluster.
-
-:::info
-You can observe the helm chart with the full installation [here](https://github.com/port-labs/helm-charts/tree/main/charts/port-agent).
-:::
-
-:::note prerequisites
-
-- The [Helm](https://helm.sh) must be installed to use the chart. Please refer to
-  the Helm's [documentation](https://helm.sh/docs) for further details on the installation;
-- The connection credentials to Kafka are provided to you by Port.
-- If you want to trigger a GitLab Pipeline, you need to have a [GitLab trigger token](https://docs.gitlab.com/ee/ci/triggers/)
-
-:::
-
-1. Add Port's Helm repo by using the following command:
-
-```bash showLineNumbers
-helm repo add port-labs https://port-labs.github.io/helm-charts
-```
-
-If you already added this repo earlier, run `helm repo update` to retrieve
-the latest versions of the charts. You can then run `helm search repo port-labs` to see the charts.
-
-2. Install the `port-agent` chart by using the following command:
-
-## Install for Webhook invocation
-
-:::note
-Remember to replace the placeholders for `YOUR_ORG_ID`, `YOUR_KAFKA_CONSUMER_GROUP`, `YOUR_PORT_CLIENT_ID` and `YOUR_PORT_CLIENT_SECRET`.
-:::
-
-```bash showLineNumbers
-helm install my-port-agent port-labs/port-agent \
-    --create-namespace --namespace port-agent \
-    --set env.normal.PORT_ORG_ID=YOUR_ORG_ID \
-    --set env.normal.KAFKA_CONSUMER_GROUP_ID=YOUR_KAFKA_CONSUMER_GROUP \
-    --set env.secret.PORT_CLIENT_ID=YOUR_PORT_CLIENT_ID \
-    --set env.secret.PORT_CLIENT_SECRET=YOUR_PORT_CLIENT_SECRET
-```
+# Usage
 
 When using the execution agent, in the `url` field you need to provide a URL to a service (for example, a REST API) that will accept the invocation event.
 
@@ -72,7 +31,8 @@ When a new invocation is detected, the agent will pull it from your Kafka topic 
 
 ![Port Execution Agent Logs](/img/self-service-actions/port-execution-agent/portAgentLogs.png)
 
-### Next steps
+
+## Next Steps
 
 Follow one of the guides below:
 


### PR DESCRIPTION
# Description

re-organzied port-agent and added argocd installation method

## Added docs pages

Please also include the path for the added docs

- helm method (`/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/helm.md`)
- argocd method (`/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/argocd.md`)
- methods (`/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/installation-methods.md`)
- usage (`/create-self-service-experiences/setup-backend/webhook/port-execution-agent/usage.md`)
- main category (`/create-self-service-experiences/setup-backend/webhook/port-execution-agent/port-execution-agent.md`)