### PR TITLE
PORT-6064 | Update Integrations Index on Port documentation with newly developed Python scripts

### DIFF
--- a/docs/integrations-index.md
+++ b/docs/integrations-index.md
@@ -25,6 +25,7 @@ This page contains a list of Port's available integrations, organized by the pla
 - [GitHub scaffolder using FastAPI backend](/create-self-service-experiences/setup-backend/webhook/examples/software-templates.md)
 - [Deploy AWS resources using AWS CloudFormation](/create-self-service-experiences/setup-backend/github-workflow/examples/deploy-cloudformation-template.md)
 - [Create GitHub secret using GitHub workflows](/create-self-service-experiences/setup-backend/github-workflow/examples/create-github-secret.md)
+- [Script to ingest GitHub packages](https://github.com/port-labs/example-github-packages)
 
 ### GitLab
 
@@ -97,6 +98,7 @@ This page contains a list of Port's available integrations, organized by the pla
 - [AWS exporter Terraform module](/build-your-software-catalog/sync-data-to-catalog/iac/terraform/modules/aws-exporter-module.md)
 - [Terraform manage S3 buckets lifecycle](/build-your-software-catalog/sync-data-to-catalog/iac/terraform/examples/s3-bucket.md)
 - [Terraform manage developer environment](/build-your-software-catalog/sync-data-to-catalog/iac/terraform/examples/create-dev-env.md)
+- [Script to ingest ECR Images and Repositories](https://github.com/port-labs/example-ecr-images)
 
 ### Azure
 
@@ -238,6 +240,11 @@ This page contains a list of Port's available integrations, organized by the pla
 ## Backstage
 
 - [Import catalog from Backstage](/guides-and-tutorials/import-backstage-resources.md)
+
+## JFrog
+- [Sync JFrog Artifacts, Docker tags, and build entities](/build-your-software-catalog/sync-data-to-catalog/webhook/?operation=ui#configuring-webhook-endpoints)
+- [Script to ingest JFrog X-ray alerts, repositories and artifacts](https://github.com/port-labs/example-jfrog-xray-alerts)
+- [Script to ingest JFrog container image builds and repositories](https://github.com/port-labs/example-jfrog-container-images)
 
 ## Webhook
 


### PR DESCRIPTION
# Description

Added integrations for:
- [Github packages](https://github.com/port-labs/example-github-packages)
- [ECR images (Repository)](https://github.com/port-labs/example-ecr-images):  
- [JFrog X-ray Alerts (Repository and Artifact)](https://github.com/port-labs/example-jfrog-xray-alerts)
- [JFrog container images (builds and repository)](https://github.com/port-labs/example-jfrog-container-images)

## Added docs pages

Please also include the path for the added docs

- Integrations Index (`/integrations-index`)

## Updated docs pages

Please also include the path for the updated docs

- Integrations Index (`/integrations-index`)
