### PR TITLE
remind user to change org name

### DIFF
--- a/docs/guides-and-tutorials/scaffold-a-new-service.md
+++ b/docs/guides-and-tutorials/scaffold-a-new-service.md
@@ -260,6 +260,7 @@ on:
 jobs:
   scaffold-service:
     env:
+# highlight-next-line
       ORG_NAME: <YOUR-ORG-NAME>
     runs-on: ubuntu-latest
     steps:

--- a/docs/guides-and-tutorials/scaffold-a-new-service.md
+++ b/docs/guides-and-tutorials/scaffold-a-new-service.md
@@ -236,7 +236,7 @@ If your organization uses SAML SSO, you will need to authorize your token. Follo
 
 <br/><br/>
 
-3. Now let's create the workflow file that contains our logic. Under `.github/workflows`, create a new file named `portCreateRepo.yaml` and use the following snippet as its content:
+3. Now let's create the workflow file that contains our logic. Under `.github/workflows`, create a new file named `portCreateRepo.yaml` and use the following snippet as its content (remember to change `<YOUR-ORG-NAME>` on line 19 to your GitHub organization name):
 
 <details>
 <summary><b>Github workflow (click to expand)</b></summary>


### PR DESCRIPTION
# Description

Adding a reminder to users to update the org name in the template `.yaml` file. Without doing so, the self-service action will fail and logs from GitHub are not understood easily enough to point this out to users who copy and paste the template without modifying the organization name. It is also unclear which org should be specified on line 19 (Port or GitHub).

## Updated docs pages

- `docs/guides-and-tutorials/scaffold-a-new-service.md`