### PR TITLE
corrected 'new input' button naming

### DIFF
--- a/docs/guides-and-tutorials/let-developers-enrich-services-using-gitops.md
+++ b/docs/guides-and-tutorials/let-developers-enrich-services-using-gitops.md
@@ -157,7 +157,7 @@ If you **skipped** the onboarding, or you want to create the action from scratch
 
 <br/><br/>
 
-4. We want our developers to be able to choose the domain to which the service will be assigned. Click on `Add input`, fill out the form like this, then click `Next`:
+4. We want our developers to be able to choose the domain to which the service will be assigned. Click on `New input`, fill out the form like this, then click `Next`:
 
 <img src='/img/guides/gitopsActionInputDomain.png' width='50%' />
 


### PR DESCRIPTION
# Description

In the [enriching services tutorial](https://docs.getport.io/guides-and-tutorials/let-developers-enrich-services-using-gitops) where [creating a frontend action](https://docs.getport.io/guides-and-tutorials/let-developers-enrich-services-using-gitops#setup-the-actions-frontend) is described, the "New input" button is called "Add input," which is not the same as in the UI. See below:

<img width="552" alt="Screenshot 2024-01-17 at 8 50 24 PM" src="https://github.com/port-labs/port-docs/assets/156127749/89ee8451-f8f1-480b-8f8c-9244923204ad">

## Updated docs pages

- Let developers enrich services using Gitops (`docs/guides-and-tutorials/let-developers-enrich-services-using-gitops.md`)