### PR TITLE
Update correcting small spelling error on integrations-index.md

### DIFF
--- a/docs/integrations-index.md
+++ b/docs/integrations-index.md
@@ -19,7 +19,7 @@ This page contains a list of Port's available integrations, organized by the pla
 - [GitHub action for GitHub workflow](/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/github-workflow/github-workflow.md)
 - [GitHub workflow self-service actions](/create-self-service-experiences/setup-backend/github-workflow/github-workflow.md)
 - [Sync repositories, file contents, pull-requests, workflows, teams and more](/build-your-software-catalog/sync-data-to-catalog/git/github/examples.md)
-- [Sync Dependebot](/build-your-software-catalog/sync-data-to-catalog/git/github/examples.md#mapping-repositories-and-dependabot-alerts)
+- [Sync Dependabot](/build-your-software-catalog/sync-data-to-catalog/git/github/examples.md#mapping-repositories-and-dependabot-alerts)
 - [GitHub scaffolder using GitHub workflows](/create-self-service-experiences/setup-backend/github-workflow/examples/scaffold-repositories-using-cookiecutter.md)
 - [GitHub scaffolder using Jenkins pipelines](/create-self-service-experiences/setup-backend/jenkins-pipeline/examples/scaffold-github-using-cookiecutter.md)
 - [GitHub scaffolder using FastAPI backend](/create-self-service-experiences/setup-backend/webhook/examples/software-templates.md)


### PR DESCRIPTION
# Description

Small spelling correction of "Dependebot" to "Dependabot"

## Updated docs pages

- Integrations index (`/integrations-index/`)
