### PR TITLE
fix broken gitlab link and add blueprint info

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_merge_request_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_merge_request_blueprint.mdx
@@ -46,7 +46,9 @@
       "required": false,
       "many": false
     }
-  }
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
 }
 ```
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
@@ -115,7 +115,7 @@ The `appHost` parameter should be set to the `url` of your GitLab integration in
 
 The GitLab integration supports listening to GitLab webhooks and updating the relevant entities in Port accordingly.
 
-Supported webhooks are [Group webhooks](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#group-webhooks) and [System hooks](https://docs.gitlab.com/ee/system_hooks/system_hooks.html).
+Supported webhooks are [Group webhooks](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#group-webhooks) and [System hooks](https://docs.gitlab.com/ee/administration/system_hooks.html).
 
 As part of the installation process, the integration will create a webhook in your GitLab instance, and will use it to listen to the relevant events.
 


### PR DESCRIPTION
# Description

Fixed broken link for GitLab system hooks. Added `calculationProperties` and `calculationProperties` to GitLab merge request blueprint example.

Previously used broken GitLab system hook link was [this](https://docs.gitlab.com/ee/system_hooks/system_hooks.html). By not including `calculationProperties` and `mirrorProperties`, the example merge request blueprint was not able to be used as it was displayed here.

## Updated docs pages
- docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_merge_request_blueprint.mdx
- docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md