### PR TITLE
Fix small typos

### DIFF
--- a/archive/_tutorial.md
+++ b/archive/_tutorial.md
@@ -405,7 +405,7 @@ the entity `aEntity` has a target entity `bEntity` mapped to it using the above 
 
 In this scenario, `bEntity` can only be deleted in one of two cases:
 
-1. `aEntity` is updated such that it's relation points to a different entity from blueprint `B`;
+1. `aEntity` is updated such that its relation points to a different entity from blueprint `B`;
 2. `aEntity` is deleted alongside `bEntity`;
 
 :::

--- a/archive/package-dependency-mapping.md
+++ b/archive/package-dependency-mapping.md
@@ -99,7 +99,7 @@ Let's have a look at our new relation!
 
 ![blueprints.png](../../../../../static/img/complete-use-cases/microservice-dependency/blueprints.png)
 
-<!-- For more information about Deployment Config and it's uses, click here (link to SDLC complete use case). -->
+<!-- For more information about Deployment Config and its uses, click here (link to SDLC complete use case). -->
 
 As we can see in the image above, two Blueprints were created: `deploymentConfig` and `package`. Notice that the `package` property is the Relation we created. It consists of an array of packages (this is thanks to the `"many": true` property of the Relation), since each microservice, and respectively, each Deployment Config can depend on multiple Packages.
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/azure-pipelines/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/azure-pipelines/examples.md
@@ -81,7 +81,7 @@ steps:
 
 ## Basic get example
 
-The following example gets the `new-cijob-run` entity from the previous example, this can be useful if your CI process creates a build artifact and then references some of it's data (for example, the run link of the latest `ciJob`).
+The following example gets the `new-cijob-run` entity from the previous example, this can be useful if your CI process creates a build artifact and then references some of its data (for example, the run link of the latest `ciJob`).
 
 Add the following snippet to your Python code:
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/circleci-workflow/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/circleci-workflow/examples.md
@@ -86,7 +86,7 @@ workflows:
 
 ## Basic get example
 
-The following example gets the `new-cijob-run` entity from the previous example, this can be useful if your CI process creates a build artifact and then references some of it's data (for example, the run link of the latest `ciJob`).
+The following example gets the `new-cijob-run` entity from the previous example, this can be useful if your CI process creates a build artifact and then references some of its data (for example, the run link of the latest `ciJob`).
 
 Add the following snippet to your Python code:
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/gitlab-pipelines/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/gitlab-pipelines/examples.md
@@ -86,7 +86,7 @@ report_to_port:
 
 ## Basic get example
 
-The following example gets the `new-cijob-run` entity from the previous example, this can be useful if your CI process creates a build artifact and then references some of it's data (for example, the run link of the latest `ciJob`).
+The following example gets the `new-cijob-run` entity from the previous example, this can be useful if your CI process creates a build artifact and then references some of its data (for example, the run link of the latest `ciJob`).
 
 Add the following snippet to your Python code:
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/jenkins-deployment/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/jenkins-deployment/examples.md
@@ -60,7 +60,7 @@ The creation was done using the `create_missing_related_entities=true` flag in t
 
 ## Basic get example
 
-The following example gets the `new-cijob-run` entity from the previous example, this can be useful if your CI process creates a build artifact and then references some of it's data (for example, the run link of the latest `ciJob`).
+The following example gets the `new-cijob-run` entity from the previous example, this can be useful if your CI process creates a build artifact and then references some of its data (for example, the run link of the latest `ciJob`).
 
 Add the following code to your Jenkins build:
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/event-based-updates.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/event-based-updates.md
@@ -186,7 +186,7 @@ For supported services in CloudTrail, click [here](https://docs.aws.amazon.com/a
 :::
 
 - The `Targets` property defines the targets of the produced events.
-  For the AWS exporter, we want to configure it's own event queue as the target:
+  For the AWS exporter, we want to configure its own event queue as the target:
 
 ```yaml showLineNumbers
 Properties:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/pagerduty.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/pagerduty.md
@@ -1025,7 +1025,7 @@ Create the following webhook configuration [using Port UI](/build-your-software-
 1. **Basic details** tab - fill the following details:
    1. Title : `PagerDuty Mapper`;
    2. Identifier : `pagerduty_mapper`;
-   3. Description : `A webhook configuration to map PagerDuty services and it's related incidents to Port`;
+   3. Description : `A webhook configuration to map PagerDuty services and its related incidents to Port`;
    4. Icon : `Pagerduty`;
 2. **Integration configuration** tab - fill the following JQ mapping:
 

--- a/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/argocd.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/argocd.md
@@ -6,7 +6,7 @@ import FindCredentials from "@site/docs/build-your-software-catalog/sync-data-to
 
 # ArgoCD
 
-This page will walk you through the installation of the Port execution agent in your Kubernetes cluster using ArgoCD, utilizing it's [Helm Capabilities](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/).
+This page will walk you through the installation of the Port execution agent in your Kubernetes cluster using ArgoCD, utilizing its [Helm Capabilities](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/).
 
 :::info
 - You can observe the Helm chart and the available parameters [here](https://github.com/port-labs/helm-charts/tree/main/charts/port-agent).

--- a/docs/create-self-service-experiences/setup-ui-for-action/advanced-form-configurations.md
+++ b/docs/create-self-service-experiences/setup-ui-for-action/advanced-form-configurations.md
@@ -567,7 +567,7 @@ action = Action(
 
 ### Hiding property based on the executing user's roles
 
-In this example, the `visible` checks if the executing user has the `"admin"` role, and if they don't have this role than the advanced option will be hidden for them. The default value will still be filled in and sent to the backend:
+In this example, the `visible` checks if the executing user has the `"admin"` role, and if they don't have this role then the advanced option will be hidden for them. The default value will still be filled in and sent to the backend:
 
 <Tabs
 defaultValue="api"

--- a/docs/promote-scorecards/promote-scorecards.md
+++ b/docs/promote-scorecards/promote-scorecards.md
@@ -38,7 +38,7 @@ A single scorecard defines a category to group different checks, validations and
 | `title`                      | `String` | Scorecard name that will be shown in the UI                                                                                                         |
 | `identifier`                 | `String` | The unique identifier of the `Scorecard`. The identifier is used for API calls, programmatic access and distinguishing between different scorecards |
 | [`filter`](#filter-elements) | `Object` | Optional set of [conditions](#conditions) to filter entities that will be evaluated by the scorecard                                                |
-| [`rules`](#rule-elements)    | `Object` | The rules that we create for each scorecard to determine it's level                                                                                 |
+| [`rules`](#rule-elements)    | `Object` | The rules that we create for each scorecard to determine its level                                                                                 |
 
 A scorecard contains and groups multiple rules that are relevant to its specific category, for example a scorecard for _service maturity_ can contain 3 rules, while the _production readiness_ scorecard can contain 2 completely different rules.
 


### PR DESCRIPTION
# Description

Fixed a than/then typo and it's/its typos.

## Updated docs pages

- Archived docs
- Examples (`/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/azure-pipelines/examples`)
- Examples (`/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/circleci-workflow/examples`)
- Examples (`/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/gitlab-pipelines/examples`)
- Examples (`/build-your-software-catalog/sync-data-to-catalog/api/ci-cd/jenkins-deployment/examples`)
- Event-Based Updates (`/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/event-based-updates`)
- PagerDuty (`/build-your-software-catalog/sync-data-to-catalog/incident-management/pagerduty`)
- ArgoCD (`/create-self-service-experiences/setup-backend/webhook/port-execution-agent/installation-methods/argocd`)
- Advanced input configurations (`/create-self-service-experiences/setup-ui-for-action/advanced-form-configurations`)
- Promote scorecards (`/promote-scorecards`)