### PR TITLE
Add top level blueprint props Jira Ocean docs

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/jira/jira.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/jira/jira.md
@@ -534,6 +534,9 @@ Examples of blueprints and the relevant integration configurations:
       }
     }
   },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
   "relations": {
     "project": {
       "target": "jiraProject",
@@ -615,7 +618,11 @@ resources:
         "description": "URL to the project in Jira"
       }
     }
-  }
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {}
 }
 ```
 


### PR DESCRIPTION
# Description

The  blueprint schemas defined in the Jira ocean docs do not have these top level properties

  "mirrorProperties": {},
  "calculationProperties": {},
  "aggregationProperties": {},
  
 This PR fixes it.

## Updated docs pages

docs/build-your-software-catalog/sync-data-to-catalog/jira/jira.md