### PR TITLE
PORT-6438 | Make sure "Let's test it" appears in all Ocean and Webhook Integrations 

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
@@ -752,3 +752,55 @@ Examples of blueprints and the relevant integration configurations:
 ```
 
 </details>
+
+## Let's Test It
+
+This section includes a sample response data from New Relic. In addition, it includes the entity created from the resync event based on the Ocean configuration provided in the previous section.
+
+### Payload
+
+Here is an example of the payload structure from New Relic:
+
+<details>
+<summary>Service (Entity) response data</summary>
+
+```json showLineNumbers
+{
+  "domain": "APM",
+  "guid": "MjQwNzIwN3xBUE18QVBQTElDQVRJT058MjIwMzEwNzV8MTA0NzYwNzA5",
+  "name": "My Service",
+  "type": "APPLICATION",
+  "tags": [
+    {
+      "key": "coreCount",
+      "values": [
+        "10"
+      ]
+    },
+    {
+      "key": "hostStatus",
+      "values": [
+        "running"
+      ]
+    }
+  ]
+}
+```
+
+</details>
+
+<details>
+<summary>Issue response data</summary>
+
+```json showLineNumbers
+{
+  "issueId": "MjQwNzIwN3xBUE18QVBQTElDQVRJT058MjIwMzEwNzV8MTA0NzYwNzA5",
+  "title": "My Issue",
+  "priority": "CRITICAL",
+  "state": "ACTIVATED",
+  "sources": ["My Source"],
+  "conditionName": ["My Condition"],
+  "policyName": ["My Policy"],
+  "activatedAt": "2022-01-01T00:00:00Z"
+}
+```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
@@ -3,7 +3,7 @@ import TabItem from "@theme/TabItem"
 import Prerequisites from "../templates/\_ocean_helm_prerequisites_block.mdx"
 import DockerParameters from "./\_newrelic-docker-parameters.mdx"
 import AzurePremise from "../templates/\_ocean_azure_premise.mdx"
-import AdvancedConfig from '../../../generalTemplates/_ocean_advanced_configuration_note.md'
+import AdvancedConfig from '../../../generalTemplates/\_ocean_advanced_configuration_note.md'
 
 # New Relic
 
@@ -78,6 +78,7 @@ helm upgrade --install my-newrelic-integration port-labs/port-ocean \
 	--set integration.secrets.newRelicAPIKey="<NR_API_KEY>"  \
 	--set integration.secrets.newRelicAccountID="<NR_ACCOUNT_ID>"
 ```
+
 </TabItem>
 <TabItem value="argocd" label="ArgoCD" default>
 To install the integration using ArgoCD, follow these steps:
@@ -87,6 +88,7 @@ To install the integration using ArgoCD, follow these steps:
 :::note
 Remember to replace the placeholders for `NEW_RELIC_API_KEY` and `NEW_RELIC_ACCOUNT_ID`.
 :::
+
 ```yaml showLineNumbers
 initializePortResources: true
 scheduledResyncInterval: 120
@@ -101,6 +103,7 @@ integration:
     newRelicAccountID: NEW_RELIC_ACCOUNT_ID
   // highlight-end
 ```
+
 <br/>
 
 :::note
@@ -122,6 +125,7 @@ integration:
     newRelicAPIKey: NEW_RELIC_API_KEY
     newRelicAccountID: NEW_RELIC_ACCOUNT_ID
 ```
+
 :::
 
 2. Install the `my-ocean-newrelic-integration` ArgoCD Application by creating the following `my-ocean-newrelic-integration.yaml` manifest:
@@ -174,9 +178,11 @@ spec:
 <br/>
 
 3. Apply your application manifest with `kubectl`:
+
 ```bash
 kubectl apply -f my-ocean-newrelic-integration.yaml
 ```
+
 </TabItem>
 </Tabs>
 
@@ -312,7 +318,7 @@ Here is an example for `newrelic-integration.yml` pipeline file:
 
 ```yaml showLineNumbers
 trigger:
-- main
+  - main
 
 pool:
   vmImage: "ubuntu-latest"
@@ -320,27 +326,25 @@ pool:
 variables:
   - group: port-ocean-credentials
 
-
 steps:
-- script: |
-    # Set Docker image and run the container
-    integration_type="newrelic"
-    version="latest"
+  - script: |
+      # Set Docker image and run the container
+      integration_type="newrelic"
+      version="latest"
 
-    image_name="ghcr.io/port-labs/port-ocean-$integration_type:$version"
+      image_name="ghcr.io/port-labs/port-ocean-$integration_type:$version"
 
-    docker run -i --rm \
-        -e OCEAN__EVENT_LISTENER='{"type":"ONCE"}' \
-        -e OCEAN__INITIALIZE_PORT_RESOURCES=true \
-        -e OCEAN__INTEGRATION__CONFIG__NEW_RELIC_API_KEY=${OCEAN__INTEGRATION__CONFIG__NEW_RELIC_API_KEY} \
-        -e OCEAN__INTEGRATION__CONFIG__NEW_RELIC_ACCOUNT_ID=${OCEAN__INTEGRATION__CONFIG__NEW_RELIC_ACCOUNT_ID} \
-        -e OCEAN__PORT__CLIENT_ID=${OCEAN__PORT__CLIENT_ID} \
-        -e OCEAN__PORT__CLIENT_SECRET=${OCEAN__PORT__CLIENT_SECRET} \
-        $image_name
+      docker run -i --rm \
+          -e OCEAN__EVENT_LISTENER='{"type":"ONCE"}' \
+          -e OCEAN__INITIALIZE_PORT_RESOURCES=true \
+          -e OCEAN__INTEGRATION__CONFIG__NEW_RELIC_API_KEY=${OCEAN__INTEGRATION__CONFIG__NEW_RELIC_API_KEY} \
+          -e OCEAN__INTEGRATION__CONFIG__NEW_RELIC_ACCOUNT_ID=${OCEAN__INTEGRATION__CONFIG__NEW_RELIC_ACCOUNT_ID} \
+          -e OCEAN__PORT__CLIENT_ID=${OCEAN__PORT__CLIENT_ID} \
+          -e OCEAN__PORT__CLIENT_SECRET=${OCEAN__PORT__CLIENT_SECRET} \
+          $image_name
 
-    exit $?
-  displayName: 'Ingest Data into Port'
-
+      exit $?
+    displayName: "Ingest Data into Port"
 ```
 
   </TabItem>
@@ -753,6 +757,7 @@ Examples of blueprints and the relevant integration configurations:
 
 </details>
 
+
 ## Let's Test It
 
 This section includes a sample response data from New Relic. In addition, it includes the entity created from the resync event based on the Ocean configuration provided in the previous section.
@@ -773,15 +778,11 @@ Here is an example of the payload structure from New Relic:
   "tags": [
     {
       "key": "coreCount",
-      "values": [
-        "10"
-      ]
+      "values": ["10"]
     },
     {
       "key": "hostStatus",
-      "values": [
-        "running"
-      ]
+      "values": ["running"]
     }
   ]
 }
@@ -804,3 +805,4 @@ Here is an example of the payload structure from New Relic:
   "activatedAt": "2022-01-01T00:00:00Z"
 }
 ```
+</details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/ci-cd/jenkins.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/ci-cd/jenkins.md
@@ -7,7 +7,7 @@ import TabItem from "@theme/TabItem"
 import Prerequisites from "../templates/\_ocean_helm_prerequisites_block.mdx"
 import AzurePremise from "../templates/\_ocean_azure_premise.mdx"
 import DockerParameters from "./\_jenkins-docker-parameters.mdx"
-import AdvancedConfig from '../../../generalTemplates/_ocean_advanced_configuration_note.md'
+import AdvancedConfig from '../../../generalTemplates/\_ocean_advanced_configuration_note.md'
 
 # Jenkins
 
@@ -23,6 +23,7 @@ Our Jenkins integration allows you to import `jobs`, `builds`, and `users` from 
 <Prerequisites />
 
 To generate a token for authenticating the Jenkins API calls:
+
 1. In the Jenkins banner frame, click your user name to open the user menu.
 2. Navigate to Your **Username** > **Configure** > **API Token**.
 3. Click Add new Token.
@@ -30,7 +31,6 @@ To generate a token for authenticating the Jenkins API calls:
 5. Copy the API token that is generated to use as the `JENKINS_TOKEN`.
 
 <img src='/img/build-your-software-catalog/sync-data-to-catalog/jenkins/configure-api-token.png' width='80%' />
-
 
 ## Installation
 
@@ -45,19 +45,19 @@ Using this installation option means that the integration will be able to update
 This table summarizes the available parameters for the installation.
 Set them as you wish in the script below, then copy it and run it in your terminal:
 
-| Parameter                           | Description                                                                                                        | Required |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- |
-| `port.clientId`                     | Your port client id ([Get the credentials](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials))                                                                                               | ✅       |
-| `port.clientSecret`                 | Your port client secret ([Get the credentials](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials))                                                                                           | ✅       |
-| `integration.identifier`            | Change the identifier to describe your integration                                                                 | ✅       |
-| `integration.type`                  | The integration type                                                                                               | ✅       |
-| `integration.eventListener.type`    | The event listener type                                                                                            | ✅       |
-| `integration.secrets.jenkinsUser`   | The Jenkins username                                                                                               | ✅       |
-| `integration.secrets.jenkinsToken`  | The Jenkins password or token                                                                                     | ✅       |
-| `integration.config.jenkinsHost`    | The Jenkins host                                                                                                  | ✅       |
-| `integration.config.appHost`        | The host of the Port Ocean app. Used to set up the integration endpoint as the target for webhooks created in Jenkins  | ❌       |
-| `scheduledResyncInterval`           | The number of minutes between each resync                                                                          | ❌       |
-| `initializePortResources`           | Default true, When set to true the integration will create default blueprints and the port App config Mapping      | ❌       |
+| Parameter                          | Description                                                                                                                                               | Required |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `port.clientId`                    | Your port client id ([Get the credentials](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials))     | ✅       |
+| `port.clientSecret`                | Your port client secret ([Get the credentials](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials)) | ✅       |
+| `integration.identifier`           | Change the identifier to describe your integration                                                                                                        | ✅       |
+| `integration.type`                 | The integration type                                                                                                                                      | ✅       |
+| `integration.eventListener.type`   | The event listener type                                                                                                                                   | ✅       |
+| `integration.secrets.jenkinsUser`  | The Jenkins username                                                                                                                                      | ✅       |
+| `integration.secrets.jenkinsToken` | The Jenkins password or token                                                                                                                             | ✅       |
+| `integration.config.jenkinsHost`   | The Jenkins host                                                                                                                                          | ✅       |
+| `integration.config.appHost`       | The host of the Port Ocean app. Used to set up the integration endpoint as the target for webhooks created in Jenkins                                     | ❌       |
+| `scheduledResyncInterval`          | The number of minutes between each resync                                                                                                                 | ❌       |
+| `initializePortResources`          | Default true, When set to true the integration will create default blueprints and the port App config Mapping                                             | ❌       |
 
 <br/>
 
@@ -73,7 +73,7 @@ helm upgrade --install my-jenkins-integration port-labs/port-ocean \
 	--set integration.eventListener.type="POLLING"  \
 	--set integration.secrets.jenkinsUser="JENKINS_USER"  \
 	--set integration.secrets.jenkinsToken="JENKINS_TOKEN" \
-	--set integration.config.jenkinsHost="JENKINS_HOST"  
+	--set integration.config.jenkinsHost="JENKINS_HOST"
 ```
 
 </TabItem>
@@ -199,7 +199,7 @@ Here is an example for `jenkins-integration.yml` pipeline file:
 
 ```yaml showLineNumbers
 trigger:
-- main
+  - main
 
 pool:
   vmImage: "ubuntu-latest"
@@ -207,28 +207,26 @@ pool:
 variables:
   - group: port-ocean-credentials
 
-
 steps:
-- script: |
-    # Set Docker image and run the container
-    integration_type="jenkins"
-    version="latest"
+  - script: |
+      # Set Docker image and run the container
+      integration_type="jenkins"
+      version="latest"
 
-    image_name="ghcr.io/port-labs/port-ocean-$integration_type:$version"
+      image_name="ghcr.io/port-labs/port-ocean-$integration_type:$version"
 
-    docker run -i --rm \
-        -e OCEAN__EVENT_LISTENER='{"type":"ONCE"}' \
-        -e OCEAN__INITIALIZE_PORT_RESOURCES=true \
-        -e OCEAN__INTEGRATION__CONFIG__JENKINS_USER=${OCEAN__INTEGRATION__CONFIG__JENKINS_USER} \
-        -e OCEAN__INTEGRATION__CONFIG__JENKINS_TOKEN=${OCEAN__INTEGRATION__CONFIG__JENKINS_TOKEN} \
-        -e OCEAN__INTEGRATION__CONFIG__JENKINS_HOST=${OCEAN__INTEGRATION__CONFIG__JENKINS_HOST} \
-        -e OCEAN__PORT__CLIENT_ID=${OCEAN__PORT__CLIENT_ID} \
-        -e OCEAN__PORT__CLIENT_SECRET=${OCEAN__PORT__CLIENT_SECRET} \
-        $image_name
+      docker run -i --rm \
+          -e OCEAN__EVENT_LISTENER='{"type":"ONCE"}' \
+          -e OCEAN__INITIALIZE_PORT_RESOURCES=true \
+          -e OCEAN__INTEGRATION__CONFIG__JENKINS_USER=${OCEAN__INTEGRATION__CONFIG__JENKINS_USER} \
+          -e OCEAN__INTEGRATION__CONFIG__JENKINS_TOKEN=${OCEAN__INTEGRATION__CONFIG__JENKINS_TOKEN} \
+          -e OCEAN__INTEGRATION__CONFIG__JENKINS_HOST=${OCEAN__INTEGRATION__CONFIG__JENKINS_HOST} \
+          -e OCEAN__PORT__CLIENT_ID=${OCEAN__PORT__CLIENT_ID} \
+          -e OCEAN__PORT__CLIENT_SECRET=${OCEAN__PORT__CLIENT_SECRET} \
+          $image_name
 
-    exit $?
-  displayName: 'Ingest Data into Port'
-
+      exit $?
+    displayName: "Ingest Data into Port"
 ```
 
   </TabItem>
@@ -271,7 +269,6 @@ The integration makes use of the [JQ JSON processor](https://stedolan.github.io/
 ### Configuration structure
 
 The integration configuration determines which resources will be queried from Jenkins, and which entities and properties will be created in Port.
-
 
 - The root key of the integration configuration is the `resources` key:
 
@@ -364,43 +361,38 @@ Examples of blueprints and the relevant integration configurations:
   "title": "Jenkins Job",
   "icon": "Jenkins",
   "schema": {
-      "properties": {
-          "jobName": {
-              "type": "string",
-              "title": "Job Name"
-          },
-          "jobStatus": {
-              "type": "string",
-              "title": "Job Status",
-              "enum": [
-                  "created",
-                  "unknown",
-                  "passing",
-                  "failing"
-              ],
-              "enumColors": {
-                  "passing": "green",
-                  "created": "darkGray",
-                  "failing": "red",
-                  "unknown": "orange"
-              }
-          },
-          "timestamp": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Timestamp",
-              "description": "Last updated timestamp of the job"
-          },
-          "url": {
-              "type": "string",
-              "title": "Project URL"
-          },
-          "parentJob": {
-              "type": "object",
-              "title": "Parent Job"
-          }
+    "properties": {
+      "jobName": {
+        "type": "string",
+        "title": "Job Name"
       },
-      "required": []
+      "jobStatus": {
+        "type": "string",
+        "title": "Job Status",
+        "enum": ["created", "unknown", "passing", "failing"],
+        "enumColors": {
+          "passing": "green",
+          "created": "darkGray",
+          "failing": "red",
+          "unknown": "orange"
+        }
+      },
+      "timestamp": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Timestamp",
+        "description": "Last updated timestamp of the job"
+      },
+      "url": {
+        "type": "string",
+        "title": "Project URL"
+      },
+      "parentJob": {
+        "type": "object",
+        "title": "Parent Job"
+      }
+    },
+    "required": []
   },
   "mirrorProperties": {},
   "calculationProperties": {},
@@ -445,62 +437,66 @@ resources:
   "description": "This blueprint represents a build event from Jenkins",
   "title": "Jenkins Build",
   "icon": "Jenkins",
-  "schema": {
-      "properties": {
-          "buildStatus": {
+  "schema":
+    {
+      "properties":
+        {
+          "buildStatus":
+            {
               "type": "string",
               "title": "Build Status",
-              "enum": [
-                  "SUCCESS",
-                  "FAILURE",
-                  "UNSTABLE"
-              ],
-              "enumColors": {
-                  "SUCCESS": "green",
-                  "FAILURE": "red",
-                  "UNSTABLE": "yellow"
-              }
-          },
-          "buildUrl": {
+              "enum": ["SUCCESS", "FAILURE", "UNSTABLE"],
+              "enumColors":
+                { "SUCCESS": "green", "FAILURE": "red", "UNSTABLE": "yellow" },
+            },
+          "buildUrl":
+            {
               "type": "string",
               "title": "Build URL",
-              "description": "URL to the build"
-          },
-          "timestamp": {
+              "description": "URL to the build",
+            },
+          "timestamp":
+            {
               "type": "string",
               "format": "date-time",
               "title": "Timestamp",
-              "description": "Last updated timestamp of the build"
-          },
-          "buildDuration": {
+              "description": "Last updated timestamp of the build",
+            },
+          "buildDuration":
+            {
               "type": "number",
               "title": "Build Duration",
-              "description": "Duration of the build"
-          }
-      },
-      "required": []
-  },
-  "mirrorProperties": {
-      "previousBuildStatus": {
+              "description": "Duration of the build",
+            },
+        },
+      "required": [],
+    },
+  "mirrorProperties":
+    {
+      "previousBuildStatus":
+        {
           "title": "Previous Build Status",
-          "path": "previousBuild.buildStatus"
-      }
-  },
+          "path": "previousBuild.buildStatus",
+        },
+    },
   "calculationProperties": {},
-  "relations": {
-      "parentJob": {
+  "relations":
+    {
+      "parentJob":
+        {
           "title": "Jenkins Job",
           "target": "jenkinsJob",
           "required": false,
-          "many": false
-      },
-      "previousBuild": {
+          "many": false,
+        },
+      "previousBuild":
+        {
           "title": "Previous Build",
           "target": "jenkinsBuild",
           "required": false,
-          "many": false
-      }
-  }
+          "many": false,
+        },
+    },
 }
 ```
 
@@ -524,14 +520,13 @@ resources:
             buildStatus: .result
             buildUrl: .url
             buildDuration: .duration
-            timestamp: '.timestamp / 1000 | todate'
+            timestamp: ".timestamp / 1000 | todate"
           relations:
             parentJob: .url | split("://")[1] | sub("^.*?/"; "") | gsub("%20"; "-") | gsub("/"; "-") | .[:-1] | gsub("-[0-9]+$"; "")
             previousBuild: .previousBuild.url | split("://")[1] | sub("^.*?/"; "") | gsub("%20"; "-") | gsub("/"; "-") | .[:-1]
 ```
 
 </details>
-
 
 ### User
 
@@ -545,20 +540,20 @@ resources:
   "title": "Jenkins User",
   "icon": "Jenkins",
   "schema": {
-      "properties": {
-          "url": {
-              "type": "string",
-              "title": "URL",
-              "format": "url"
-          },
-          "lastUpdateTime": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Last Update",
-              "description": "Last updated timestamp of the user"
-          }
+    "properties": {
+      "url": {
+        "type": "string",
+        "title": "URL",
+        "format": "url"
       },
-      "required": []
+      "lastUpdateTime": {
+        "type": "string",
+        "format": "date-time",
+        "title": "Last Update",
+        "description": "Last updated timestamp of the user"
+      }
+    },
+    "required": []
   },
   "mirrorProperties": {},
   "calculationProperties": {},

--- a/docs/build-your-software-catalog/sync-data-to-catalog/ci-cd/jenkins.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/ci-cd/jenkins.md
@@ -589,3 +589,164 @@ resources:
 ```
 
 </details>
+
+## Let's Test It
+
+This section includes a sample response data from Jenkins. In addition, it includes the entity created from the resync event based on the Ocean configuration provided in the previous section.
+
+### Payload
+
+Here is an example of the payload structure from Jenkins:
+
+<details>
+<summary>Job response data</summary>
+  
+```json showLineNumbers
+{
+  "_class" : "hudson.model.FreeStyleProject",
+  "displayName" : "Hello Job",
+  "fullName" : "Hello Job",
+  "name" : "Hello Job",
+  "url" : "http://localhost:8080/job/Hello%20Job/",
+  "buildable" : true,
+  "builds" : [
+    {
+      "_class" : "hudson.model.FreeStyleBuild",
+      "displayName" : "#2",
+      "duration" : 221,
+      "fullDisplayName" : "Hello Job #2",
+      "id" : "2",
+      "number" : 2,
+      "result" : "SUCCESS",
+      "timestamp" : 1700569094576,
+      "url" : "http://localhost:8080/job/Hello%20Job/2/"
+    },
+    {
+      "_class" : "hudson.model.FreeStyleBuild",
+      "displayName" : "#1",
+      "duration" : 2214,
+      "fullDisplayName" : "Hello Job #1",
+      "id" : "1",
+      "number" : 1,
+      "result" : "SUCCESS",
+      "timestamp" : 1700567994163,
+      "url" : "http://localhost:8080/job/Hello%20Job/1/"
+    }
+  ],
+  "color" : "blue"
+}
+```
+
+</details>
+
+<details>
+<summary>Build response data</summary>
+  
+```json showLineNumbers
+{
+  "_class" : "hudson.model.FreeStyleBuild",
+  "displayName" : "#2",
+  "duration" : 221,
+  "fullDisplayName" : "Hello Job #2",
+  "id" : "2",
+  "number" : 2,
+  "result" : "SUCCESS",
+  "timestamp" : 1700569094576,
+  "url" : "http://localhost:8080/job/Hello%20Job/2/"
+}
+```
+
+</details>
+
+<details>
+<summary>User response data</summary>
+  
+```json showLineNumbers
+{
+  "user" : {
+    "absoluteUrl" : "http://localhost:8080/user/admin",
+    "fullName" : "admin",
+    "description" : "System Administrator",
+    "id" : "admin"
+  },
+  "lastChange" : 1700569094576
+}
+```
+
+</details>
+
+### Mapping Result
+
+The combination of the sample payload and the Ocean configuration generates the following Port entity:
+
+<details>
+<summary>Job entity</summary>
+  
+```json showLineNumbers
+{
+  "identifier": "hello-job",
+  "title": "Hello Job",
+  "blueprint": "jenkinsJob",
+  "properties": {
+    "jobName": "Hello Job",
+    "url": "http://localhost:8080/job/Hello%20Job/",
+    "jobStatus": "passing",
+    "timestamp": "2023-09-08T14:58:14Z"
+  },
+  "relations": {},
+  "createdAt": "2023-12-18T08:37:21.637Z",
+  "createdBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW",
+  "updatedAt": "2023-12-18T08:37:21.637Z",
+  "updatedBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW"
+}
+```
+
+</details>
+
+<details>
+<summary>Build entity</summary>
+  
+```json showLineNumbers
+{
+  "identifier": "hello-job-2",
+  "title": "Hello Job #2",
+  "blueprint": "jenkinsBuild",
+  "properties": {
+    "buildStatus": "SUCCESS",
+    "buildUrl": "http://localhost:8080/job/Hello%20Job/2/",
+    "buildDuration": 221,
+    "timestamp": "2023-09-08T14:58:14Z"
+  },
+  "relations": {
+    "parentJob": "hello-job"
+  },
+  "createdAt": "2023-12-18T08:37:21.637Z",
+  "createdBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW",
+  "updatedAt": "2023-12-18T08:37:21.637Z",
+  "updatedBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW"
+}
+```
+
+</details>
+
+<details>
+<summary>User entity</summary>
+  
+```json showLineNumbers
+{
+  "identifier": "admin",
+  "title": "admin",
+  "blueprint": "jenkinsUser",
+  "properties": {
+    "url": "http://localhost:8080/user/admin",
+    "lastUpdateTime": "2023-09-08T14:58:14Z"
+  },
+  "relations": {},
+  "createdAt": "2023-12-18T08:37:21.637Z",
+  "createdBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW",
+  "updatedAt": "2023-12-18T08:37:21.637Z",
+  "updatedBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW"
+}
+```
+
+</details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk.md
@@ -32,23 +32,22 @@ Using this installation option means that the integration will be able to update
 This table summarizes the available parameters for the installation.
 Set them as you wish in the script below, then copy it and run it in your terminal:
 
-
-| Parameter                           | Description                                                                                                        | Required |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- |
-| `port.clientId`                     | Your Port client id                                                                                                | ✅       |
-| `port.clientSecret`                 | Your Port client secret                                                                                            | ✅       |
-| `port.baseUrl`                      | Your Port base url, relevant only if not using the default Port app                                                | ❌       |
-| `integration.identifier`            | Change the identifier to describe your integration                                                                 | ✅       |
-| `integration.type`                  | The integration type                                                                                               | ✅       |
-| `integration.eventListener.type`    | The event listener type                                                                                            | ✅       |
-| `integration.secrets.token`         | The Snyk API token                                                                                                 | ✅       |
-| `integration.config.organizationId` | The Snyk organization ID. Fetches data for this organization when provided                                                                     |❌       |
-| `integration.config.groups` | A comma-separated list of Snyk group ids to filter data for. Fetches data for organizations within the specified groups                                                          |❌       |
-| `integration.config.apiUrl`         | The Snyk API URL. If not specified, the default will be https://api.snyk.io                                        | ❌       |
-| `integration.config.appHost`        | The host of the Port Ocean app. Used to set up the integration endpoint as the target for Webhooks created in Snyk | ❌       |
-| `integration.secret.webhookSecret`  | This is a password you create, that Snyk uses to sign webhook events to Port                                       | ❌       |
-| `scheduledResyncInterval`           | The number of minutes between each resync                                                                          | ❌       |
-| `initializePortResources`           | Default true, When set to true the integration will create default blueprints and the port App config Mapping      | ❌       |
+| Parameter                           | Description                                                                                                             | Required |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------- |
+| `port.clientId`                     | Your Port client id                                                                                                     | ✅       |
+| `port.clientSecret`                 | Your Port client secret                                                                                                 | ✅       |
+| `port.baseUrl`                      | Your Port base url, relevant only if not using the default Port app                                                     | ❌       |
+| `integration.identifier`            | Change the identifier to describe your integration                                                                      | ✅       |
+| `integration.type`                  | The integration type                                                                                                    | ✅       |
+| `integration.eventListener.type`    | The event listener type                                                                                                 | ✅       |
+| `integration.secrets.token`         | The Snyk API token                                                                                                      | ✅       |
+| `integration.config.organizationId` | The Snyk organization ID. Fetches data for this organization when provided                                              | ❌       |
+| `integration.config.groups`         | A comma-separated list of Snyk group ids to filter data for. Fetches data for organizations within the specified groups | ❌       |
+| `integration.config.apiUrl`         | The Snyk API URL. If not specified, the default will be https://api.snyk.io                                             | ❌       |
+| `integration.config.appHost`        | The host of the Port Ocean app. Used to set up the integration endpoint as the target for Webhooks created in Snyk      | ❌       |
+| `integration.secret.webhookSecret`  | This is a password you create, that Snyk uses to sign webhook events to Port                                            | ❌       |
+| `scheduledResyncInterval`           | The number of minutes between each resync                                                                               | ❌       |
+| `initializePortResources`           | Default true, When set to true the integration will create default blueprints and the port App config Mapping           | ❌       |
 
 <br/>
 
@@ -81,6 +80,7 @@ helm upgrade --install my-snyk-integration port-labs/port-ocean \
 	--set integration.eventListener.type="POLLING"  \
 	--set integration.secrets.token="SNYK_TOKEN"
 ```
+
 </TabItem>
 <TabItem value="argocd" label="ArgoCD" default>
 To install the integration using ArgoCD, follow these steps:
@@ -105,11 +105,12 @@ integration:
   // highlight-next-line
     token: SNYK_TOKEN
 ```
+
 <br/>
 
- If you wish to customize access, the following configurations are available:
+If you wish to customize access, the following configurations are available:
 
- - The `organizationId` key is used to restrict access to a specific organization. If specified in the `values.yaml` file, the integration will fetch data only for the provided organization.
+- The `organizationId` key is used to restrict access to a specific organization. If specified in the `values.yaml` file, the integration will fetch data only for the provided organization.
 
 :::note Configuration variable replacement
 Remember to replace the placeholders for `SNYK_TOKEN` and `SNYK_ORGANIZATION_ID`.
@@ -129,9 +130,10 @@ integration:
   secrets:
     token: SNYK_TOKEN
 ```
+
 <br/>
 
- - The `groups` key is used to restrict access to all organizations within specific Snyk groups. In the `values.yaml` file, provide a comma-separated list of Snyk group IDs to the `groups` key, and the integration will filter data for all organizations in the group(s).
+- The `groups` key is used to restrict access to all organizations within specific Snyk groups. In the `values.yaml` file, provide a comma-separated list of Snyk group IDs to the `groups` key, and the integration will filter data for all organizations in the group(s).
 
 :::note Configuration variable replacement
 Remember to replace the placeholders for `SNYK_TOKEN` and `SNYK_GROUPS`.
@@ -151,11 +153,12 @@ integration:
   secrets:
     token: SNYK_TOKEN
 ```
+
 <br/>
 
 2. Install the `my-ocean-snyk-integration` ArgoCD Application by creating the following `my-ocean-snyk-integration.yaml` manifest:
-:::note Configuration variable replacement
-Remember to replace the placeholders for `YOUR_PORT_CLIENT_ID` `YOUR_PORT_CLIENT_SECRET` and `YOUR_GIT_REPO_URL`.
+   :::note Configuration variable replacement
+   Remember to replace the placeholders for `YOUR_PORT_CLIENT_ID` `YOUR_PORT_CLIENT_SECRET` and `YOUR_GIT_REPO_URL`.
 
 Multiple sources ArgoCD documentation can be found [here](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/#helm-value-files-from-external-git-repository).
 :::
@@ -203,9 +206,11 @@ spec:
 <br/>
 
 3. Apply your application manifest with `kubectl`:
+
 ```bash
 kubectl apply -f my-ocean-snyk-integration.yaml
 ```
+
 </TabItem>
 </Tabs>
 
@@ -213,15 +218,15 @@ kubectl apply -f my-ocean-snyk-integration.yaml
 
 <TabItem value="one-time" label="Scheduled">
 
-  By default, the integration fetches all organizations associated with the provided Snyk token. If you wish to customize access, the following parameters are available:
+By default, the integration fetches all organizations associated with the provided Snyk token. If you wish to customize access, the following parameters are available:
 
-  `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ID`: Use this parameter to restrict access to a specific organization. If specified, the integration will fetch data only for the provided organization.
+`OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ID`: Use this parameter to restrict access to a specific organization. If specified, the integration will fetch data only for the provided organization.
 
-  `OCEAN__INTEGRATION__CONFIG__GROUPS`: When you want to limit access to all organizations within specific Snyk groups, use this parameter. Provide a comma-separated list of Snyk group IDs, and the integration will filter data accordingly.
+`OCEAN__INTEGRATION__CONFIG__GROUPS`: When you want to limit access to all organizations within specific Snyk groups, use this parameter. Provide a comma-separated list of Snyk group IDs, and the integration will filter data accordingly.
 
-  :::note Default behaviour
-  If neither parameter is provided, the integration will operate with the default behavior of fetching all organizations associated with the supplied Snyk token.
-  :::
+:::note Default behaviour
+If neither parameter is provided, the integration will operate with the default behavior of fetching all organizations associated with the supplied Snyk token.
+:::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">
   <TabItem value="github" label="GitHub">
@@ -233,17 +238,17 @@ If you want the integration to update Port in real time using webhooks you shoul
 
 Make sure to configure the following [Github Secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions):
 
-| Parameter                                     | Description                                                                                                        | Required |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- |
-| `OCEAN__INTEGRATION__CONFIG__TOKEN`           | The Snyk API token                                                                                                 | ✅       |
-| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ID` | The Snyk organization ID. Provide this parameter to limit access to a specific organization.                                                                                       | ❌      |
-| `OCEAN__INTEGRATION__CONFIG__GROUPS` | A comma-separated list of Snyk group ids to filter data for. Provide this parameter to limit access to all organizations within specific group(s)                                                   | ❌      |
-| `OCEAN__INTEGRATION__CONFIG__API_URL`         | The Snyk API URL. If not specified, the default will be https://api.snyk.io                                        | ❌       |
-| `OCEAN__INITIALIZE_PORT_RESOURCES`            | Default true, When set to false the integration will not create default blueprints and the port App config Mapping | ❌       |
-| `OCEAN__INTEGRATION__IDENTIFIER`              | Change the identifier to describe your integration, if not set will use the default one                            | ❌       |
-| `OCEAN__PORT__CLIENT_ID`                      | Your port client id                                                                                                | ✅       |
-| `OCEAN__PORT__CLIENT_SECRET`                  | Your port client secret                                                                                            | ✅       |
-| `OCEAN__PORT__BASE_URL`                       | Your port base url, relevant only if not using the default port app                                                | ❌       |
+| Parameter                                     | Description                                                                                                                                       | Required |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `OCEAN__INTEGRATION__CONFIG__TOKEN`           | The Snyk API token                                                                                                                                | ✅       |
+| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ID` | The Snyk organization ID. Provide this parameter to limit access to a specific organization.                                                      | ❌       |
+| `OCEAN__INTEGRATION__CONFIG__GROUPS`          | A comma-separated list of Snyk group ids to filter data for. Provide this parameter to limit access to all organizations within specific group(s) | ❌       |
+| `OCEAN__INTEGRATION__CONFIG__API_URL`         | The Snyk API URL. If not specified, the default will be https://api.snyk.io                                                                       | ❌       |
+| `OCEAN__INITIALIZE_PORT_RESOURCES`            | Default true, When set to false the integration will not create default blueprints and the port App config Mapping                                | ❌       |
+| `OCEAN__INTEGRATION__IDENTIFIER`              | Change the identifier to describe your integration, if not set will use the default one                                                           | ❌       |
+| `OCEAN__PORT__CLIENT_ID`                      | Your port client id                                                                                                                               | ✅       |
+| `OCEAN__PORT__CLIENT_SECRET`                  | Your port client secret                                                                                                                           | ✅       |
+| `OCEAN__PORT__BASE_URL`                       | Your port base url, relevant only if not using the default port app                                                                               | ❌       |
 
 <br/>
 
@@ -299,8 +304,8 @@ of `Secret Text` type:
 | Parameter                                     | Description                                                                                                                                                      | Required |
 | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | `OCEAN__INTEGRATION__CONFIG__TOKEN`           | The Snyk API token                                                                                                                                               | ✅       |
-| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ID` | The Snyk organization ID. Provide this parameter to limit access to a specific organization | ❌  |
-| `OCEAN__INTEGRATION__CONFIG__GROUPS` | A comma-separated list of Snyk group ids to filter data for. Provide this parameter to limit access to all organizations within specific group(s)                                       | ❌      |
+| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ID` | The Snyk organization ID. Provide this parameter to limit access to a specific organization                                                                      | ❌       |
+| `OCEAN__INTEGRATION__CONFIG__GROUPS`          | A comma-separated list of Snyk group ids to filter data for. Provide this parameter to limit access to all organizations within specific group(s)                | ❌       |
 | `OCEAN__INTEGRATION__CONFIG__API_URL`         | The Snyk API URL. If not specified, the default will be https://api.snyk.io                                                                                      | ❌       |
 | `OCEAN__INITIALIZE_PORT_RESOURCES`            | Default true, When set to false the integration will not create default blueprints and the port App config Mapping                                               | ❌       |
 | `OCEAN__INTEGRATION__IDENTIFIER`              | Change the identifier to describe your integration, if not set will use the default one                                                                          | ❌       |
@@ -366,8 +371,8 @@ Make sure to configure the following variables using [Azure Devops variable grou
 | Parameter                                     | Description                                                                                                                                                      | Required |
 | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | `OCEAN__INTEGRATION__CONFIG__TOKEN`           | The Snyk API token                                                                                                                                               | ✅       |
-| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ID` | The Snyk organization ID. Provide this parameter to limit access to a specific organization | ❌  |
-| `OCEAN__INTEGRATION__CONFIG__GROUPS` | A comma-separated list of Snyk group ids to filter data for. Provide this parameter to limit access to all organizations within specific group(s)                                       | ❌      |
+| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ID` | The Snyk organization ID. Provide this parameter to limit access to a specific organization                                                                      | ❌       |
+| `OCEAN__INTEGRATION__CONFIG__GROUPS`          | A comma-separated list of Snyk group ids to filter data for. Provide this parameter to limit access to all organizations within specific group(s)                | ❌       |
 | `OCEAN__INTEGRATION__CONFIG__API_URL`         | The Snyk API URL. If not specified, the default will be https://api.snyk.io                                                                                      | ❌       |
 | `OCEAN__INITIALIZE_PORT_RESOURCES`            | Default true, When set to false the integration will not create default blueprints and the port App config Mapping                                               | ❌       |
 | `OCEAN__INTEGRATION__IDENTIFIER`              | Change the identifier to describe your integration, if not set will use the default one                                                                          | ❌       |
@@ -381,7 +386,7 @@ Here is an example for `snyk-integration.yml` pipeline file:
 
 ```yaml showLineNumbers
 trigger:
-- main
+  - main
 
 pool:
   vmImage: "ubuntu-latest"
@@ -389,27 +394,25 @@ pool:
 variables:
   - group: port-ocean-credentials # OCEAN__PORT__CLIENT_ID, OCEAN__PORT__CLIENT_SECRET, OCEAN__INTEGRATION__CONFIG__TOKEN
 
-
 steps:
-- script: |
-    echo Add other tasks to build, test, and deploy your project.
-    # Set Docker image and run the container
-    integration_type="snyk"
-    version="latest"
+  - script: |
+      echo Add other tasks to build, test, and deploy your project.
+      # Set Docker image and run the container
+      integration_type="snyk"
+      version="latest"
 
-    image_name="ghcr.io/port-labs/port-ocean-$integration_type:$version"
+      image_name="ghcr.io/port-labs/port-ocean-$integration_type:$version"
 
-    docker run -i --rm \
-    -e OCEAN__EVENT_LISTENER='{"type":"ONCE"}' \
-    -e OCEAN__INITIALIZE_PORT_RESOURCES=true \
-    -e OCEAN__INTEGRATION__CONFIG__TOKEN=${OCEAN__INTEGRATION__CONFIG__TOKEN} \
-    -e OCEAN__PORT__CLIENT_ID=${OCEAN__PORT__CLIENT_ID} \
-    -e OCEAN__PORT__CLIENT_SECRET=${OCEAN__PORT__CLIENT_SECRET} \
-    $image_name
+      docker run -i --rm \
+      -e OCEAN__EVENT_LISTENER='{"type":"ONCE"}' \
+      -e OCEAN__INITIALIZE_PORT_RESOURCES=true \
+      -e OCEAN__INTEGRATION__CONFIG__TOKEN=${OCEAN__INTEGRATION__CONFIG__TOKEN} \
+      -e OCEAN__PORT__CLIENT_ID=${OCEAN__PORT__CLIENT_ID} \
+      -e OCEAN__PORT__CLIENT_SECRET=${OCEAN__PORT__CLIENT_SECRET} \
+      $image_name
 
-    exit $?
-  displayName: 'Ingest Synk Data into Port'
-
+      exit $?
+    displayName: "Ingest Synk Data into Port"
 ```
 
   </TabItem>
@@ -595,7 +598,7 @@ Examples of blueprints and the relevant integration configurations:
 ```yaml showLineNumbers
 - kind: organization
   selector:
-    query: 'true'
+    query: "true"
   port:
     entity:
       mappings:
@@ -606,8 +609,8 @@ Examples of blueprints and the relevant integration configurations:
           slug: .slug
           url: ("https://app.snyk.io/org/" + .slug | tostring)
 ```
-</details>
 
+</details>
 
 ### Target
 
@@ -737,12 +740,7 @@ Examples of blueprints and the relevant integration configurations:
         "type": "array",
         "items": {
           "type": "string",
-          "enum": [
-            "critical",
-            "high",
-            "medium",
-            "low"
-          ]
+          "enum": ["critical", "high", "medium", "low"]
         },
         "icon": "DefaultProperty"
       },
@@ -770,11 +768,7 @@ Examples of blueprints and the relevant integration configurations:
         "type": "array",
         "items": {
           "type": "string",
-          "enum": [
-            "development",
-            "sandbox",
-            "production"
-          ]
+          "enum": ["development", "sandbox", "production"]
         },
         "icon": "DefaultProperty"
       },
@@ -834,7 +828,7 @@ Examples of blueprints and the relevant integration configurations:
 ```yaml showLineNumbers
 - kind: project
   selector:
-    query: 'true'
+    query: "true"
   port:
     entity:
       mappings:
@@ -870,78 +864,72 @@ Examples of blueprints and the relevant integration configurations:
   "identifier": "snykVulnerability",
   "title": "Snyk Vulnerability",
   "icon": "Snyk",
-  "schema": {
-    "properties": {
-      "score": {
-        "icon": "Star",
-        "type": "number",
-        "title": "Score"
-      },
-      "packageName": {
-        "type": "string",
-        "title": "Package Name",
-        "icon": "DefaultProperty"
-      },
-      "packageVersions": {
-        "icon": "Package",
-        "title": "Package Versions",
-        "type": "array"
-      },
-      "type": {
-        "type": "string",
-        "title": "Type",
-        "enum": [
-          "vuln",
-          "license",
-          "configuration"
-        ],
-        "icon": "DefaultProperty"
-      },
-      "severity": {
-        "icon": "Alert",
-        "title": "Issue Severity",
-        "type": "string",
-        "enum": [
-          "low",
-          "medium",
-          "high",
-          "critical"
-        ],
-        "enumColors": {
-          "low": "green",
-          "medium": "yellow",
-          "high": "red",
-          "critical": "red"
-        }
-      },
-      "url": {
-        "icon": "Link",
-        "type": "string",
-        "title": "Issue URL",
-        "format": "url"
-      },
-      "language": {
-        "type": "string",
-        "title": "Language",
-        "icon": "DefaultProperty"
-      },
-      "publicationTime": {
-        "type": "string",
-        "format": "date-time",
-        "title": "Publication Time",
-        "icon": "DefaultProperty"
-      },
-      "isPatched": {
-        "type": "boolean",
-        "title": "Is Patched",
-        "icon": "DefaultProperty"
-      }
+  "schema":
+    {
+      "properties":
+        {
+          "score": { "icon": "Star", "type": "number", "title": "Score" },
+          "packageName":
+            {
+              "type": "string",
+              "title": "Package Name",
+              "icon": "DefaultProperty",
+            },
+          "packageVersions":
+            { "icon": "Package", "title": "Package Versions", "type": "array" },
+          "type":
+            {
+              "type": "string",
+              "title": "Type",
+              "enum": ["vuln", "license", "configuration"],
+              "icon": "DefaultProperty",
+            },
+          "severity":
+            {
+              "icon": "Alert",
+              "title": "Issue Severity",
+              "type": "string",
+              "enum": ["low", "medium", "high", "critical"],
+              "enumColors":
+                {
+                  "low": "green",
+                  "medium": "yellow",
+                  "high": "red",
+                  "critical": "red",
+                },
+            },
+          "url":
+            {
+              "icon": "Link",
+              "type": "string",
+              "title": "Issue URL",
+              "format": "url",
+            },
+          "language":
+            {
+              "type": "string",
+              "title": "Language",
+              "icon": "DefaultProperty",
+            },
+          "publicationTime":
+            {
+              "type": "string",
+              "format": "date-time",
+              "title": "Publication Time",
+              "icon": "DefaultProperty",
+            },
+          "isPatched":
+            {
+              "type": "boolean",
+              "title": "Is Patched",
+              "icon": "DefaultProperty",
+            },
+        },
+      "required": [],
     },
-    "required": []
-  },
   "mirrorProperties": {},
   "calculationProperties": {},
-  "relations": {}
+  "relations": {},
 }
 ```
 
@@ -974,7 +962,185 @@ Examples of blueprints and the relevant integration configurations:
 
 </details>
 
+## Let's Test It
+
+This section includes a sample response data from Snyk. In addition, it includes the entity created from the resync event based on the Ocean configuration provided in the previous section.
+
+### Payload
+
+Here is an example of the payload structure from Snyk:
+
+<details>
+<summary>Organization response data</summary>
+
+```json showLineNumbers
+{
+  "name": "My Other Org",
+  "id": "a04d9cbd-ae6e-44af-b573-0556b0ad4bd2",
+  "slug": "my-other-org",
+  "url": "https://api.snyk.io/org/my-other-org",
+  "group": {
+    "name": "ACME Inc.",
+    "id": "a060a49f-636e-480f-9e14-38e773b2a97f"
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Target response data</summary>
+
+```json showLineNumbers
+
+```
+
+</details>
+
+<details>
+<summary>Project response data</summary>
+
+```json showLineNumbers
+{
+  "name": "snyk/goof",
+  "id": "af137b96-6966-46c1-826b-2e79ac49bbd9",
+  "created": "2018-10-29T09:50:54.014Z",
+  "origin": "github",
+  "type": "maven",
+  "readOnly": false,
+  "testFrequency": "daily",
+  "totalDependencies": 42,
+  "issueCountsBySeverity": {
+    "low": 13,
+    "medium": 8,
+    "high": 1,
+    "critical": 3
+  },
+  "imageId": "sha256:caf27325b298a6730837023a8a342699c8b7b388b8d878966b064a1320043019",
+  "imageTag": "latest",
+  "imageBaseImage": "alpine:3",
+  "imagePlatform": "linux/arm64",
+  "imageCluster": "Production",
+  "hostname": null,
+  "remoteRepoUrl": "https://github.com/snyk/goof.git",
+  "lastTestedDate": "2019-02-05T08:54:07.704Z",
+  "browseUrl": "https://app.snyk.io/org/4a18d42f-0706-4ad0-b127-24078731fbed/project/af137b96-6966-46c1-826b-2e79ac49bbd9",
+  "importingUser": {
+    "id": "e713cf94-bb02-4ea0-89d9-613cce0caed2",
+    "name": "example-user@snyk.io",
+    "username": "exampleUser",
+    "email": "example-user@snyk.io"
+  },
+  "isMonitored": false,
+  "branch": null,
+  "targetReference": null,
+  "tags": [
+    {
+      "key": "example-tag-key",
+      "value": "example-tag-value"
+    }
+  ],
+  "attributes": {
+    "criticality": ["high"],
+    "environment": ["backend"],
+    "lifecycle": ["development"]
+  },
+  "remediation": {
+    "upgrade": {},
+    "patch": {},
+    "pin": {}
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>Vulnerability response data</summary>
+
+```json showLineNumbers
+{
+  "id": "npm:ms:20170412",
+  "issueType": "vuln",
+  "pkgName": "ms",
+  "pkgVersions": ["1.0.0"],
+  "issueData": {
+    "id": "npm:ms:20170412",
+    "title": "Regular Expression Denial of Service (ReDoS)",
+    "severity": "low",
+    "originalSeverity": "high",
+    "url": "https://snyk.io/vuln/npm:ms:20170412",
+    "description": "`## Overview\\r\\n[`ms`](https://www.npmjs.com/package/ms) is a tiny millisecond conversion utility.\\r\\n\\r\\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) due to an incomplete fix for previously reported vulnerability [npm:ms:20151024](https://snyk.io/vuln/npm:ms:20151024). The fix limited the length of accepted input string to 10,000 characters, and turned to be insufficient making it possible to block the event loop for 0.3 seconds (on a typical laptop) with a specially crafted string passed to `ms",
+    "identifiers": {
+      "CVE": [],
+      "CWE": ["CWE-400"],
+      "OSVDB": []
+    },
+    "credit": ["Snyk Security Research Team"],
+    "exploitMaturity": "no-known-exploit",
+    "semver": {
+      "vulnerable": [">=0.7.1 <2.0.0"],
+      "unaffected": ""
+    },
+    "publicationTime": "2017-05-15T06:02:45Z",
+    "disclosureTime": "2017-04-11T21:00:00Z",
+    "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+    "cvssScore": 3.7,
+    "language": "js",
+    "patches": [
+      {
+        "id": "patch:npm:ms:20170412:0",
+        "urls": [
+          "https://snyk-patches.s3.amazonaws.com/npm/ms/20170412/ms_100.patch"
+        ],
+        "version": "=1.0.0",
+        "comments": [],
+        "modificationTime": "2019-12-03T11:40:45.863964Z"
+      }
+    ],
+    "nearestFixedInVersion": "2.0.0",
+    "path": "[DocId: 1].input.spec.template.spec.containers[snyk2].securityContext.privileged",
+    "violatedPolicyPublicId": "SNYK-CC-K8S-1",
+    "isMaliciousPackage": true
+  },
+  "introducedThrough": [
+    {
+      "kind": "imageLayer",
+      "data": {}
+    }
+  ],
+  "isPatched": false,
+  "isIgnored": false,
+  "ignoreReasons": [
+    {
+      "reason": "",
+      "expires": "",
+      "source": "cli"
+    }
+  ],
+  "fixInfo": {
+    "isUpgradable": false,
+    "isPinnable": false,
+    "isPatchable": false,
+    "isFixable": false,
+    "isPartiallyFixable": false,
+    "nearestFixedInVersion": "2.0.0",
+    "fixedIn": ["2.0.0"]
+  },
+  "priority": {
+    "score": 399,
+    "factors": [{}, "name: `isFixable`", "description: `Has a fix available`"]
+  },
+  "links": {
+    "paths": ""
+  }
+}
+```
+
+</details>
+
 ## Alternative installation via webhook
+
 While the Ocean integration described above is the recommended installation method, you may prefer to use a webhook to ingest data from Snyk. If so, use the following instructions:
 
 <details>
@@ -1051,4 +1217,5 @@ curl -X POST \
 :::
 
 Done! Any vulnerability detected on your source code will trigger a webhook event to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.
+
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk.md
@@ -157,8 +157,8 @@ integration:
 <br/>
 
 2. Install the `my-ocean-snyk-integration` ArgoCD Application by creating the following `my-ocean-snyk-integration.yaml` manifest:
-   :::note Configuration variable replacement
-   Remember to replace the placeholders for `YOUR_PORT_CLIENT_ID` `YOUR_PORT_CLIENT_SECRET` and `YOUR_GIT_REPO_URL`.
+:::note Configuration variable replacement
+Remember to replace the placeholders for `YOUR_PORT_CLIENT_ID` `YOUR_PORT_CLIENT_SECRET` and `YOUR_GIT_REPO_URL`.
 
 Multiple sources ArgoCD documentation can be found [here](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/#helm-value-files-from-external-git-repository).
 :::
@@ -991,9 +991,9 @@ Here is an example of the payload structure from Snyk:
 <details>
 <summary>Target response data</summary>
 
-```json showLineNumbers
+<!-- ```json showLineNumbers
 
-```
+``` -->
 
 </details>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/__dynatrace.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/__dynatrace.md
@@ -23,18 +23,18 @@ Using this installation option means that the integration will be able to update
 This table summarizes the available parameters for the installation.
 Set them as you wish in the script below, then copy it and run it in your terminal:
 
-| Parameter                             | Description                                                                                                   | Required |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------- |
-| `port.clientId`                       | Your port [client id](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials)                                                                                           | ✅       |
-| `port.clientSecret`                   | Your port [client secret](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials)                                                                                       | ✅       |
-| `port.baseUrl`                        | Your port base url, relevant only if not using the default port app                                           | ❌       |
-| `integration.identifier`              | Change the identifier to describe your integration                                                            | ✅       |
-| `integration.type`                    | The integration type                                                                                          | ✅       |
-| `integration.eventListener.type`      | The event listener type                                                                                       | ✅       |
-| `integration.secrets.dynatraceApiKey` | API Key for Dynatrace instance                                                                          | ✅       |
-| `integration.config.dynatraceHostUrl` | The URL to the Dynatrace instance                                                                          | ✅       |
-| `scheduledResyncInterval`             | The number of minutes between each resync                                                                     | ❌       |
-| `initializePortResources`             | Default true, When set to true the integration will create default blueprints and the port App config Mapping | ❌       |
+| Parameter                             | Description                                                                                                                         | Required |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `port.clientId`                       | Your port [client id](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials)     | ✅       |
+| `port.clientSecret`                   | Your port [client secret](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials) | ✅       |
+| `port.baseUrl`                        | Your port base url, relevant only if not using the default port app                                                                 | ❌       |
+| `integration.identifier`              | Change the identifier to describe your integration                                                                                  | ✅       |
+| `integration.type`                    | The integration type                                                                                                                | ✅       |
+| `integration.eventListener.type`      | The event listener type                                                                                                             | ✅       |
+| `integration.secrets.dynatraceApiKey` | API Key for Dynatrace instance                                                                                                      | ✅       |
+| `integration.config.dynatraceHostUrl` | The URL to the Dynatrace instance                                                                                                   | ✅       |
+| `scheduledResyncInterval`             | The number of minutes between each resync                                                                                           | ❌       |
+| `initializePortResources`             | Default true, When set to true the integration will create default blueprints and the port App config Mapping                       | ❌       |
 
 <br/>
 
@@ -323,16 +323,14 @@ Prepare a webhook `URL` using this format: `{app_host}/integration/webhook`. The
    3. `Webhook URL` - enter the value of the `URL` you created above.;
    4. Enable **Call webhook is new events merge into existing problems**;
    5. `Custom payload` - paste the following configuration:
-    ```
-    {
-        "State":"{State}",
-        "ProblemID":"{ProblemID}",
-        "ProblemTitle":"{ProblemTitle}"
-    }
-    ```
-    You can customize to your taste, the only important thing is the `ProblemID` key. The webhook integration will not work without it.
-   6. `Alerting profile` - select the corresponding alerting profile
-   7. Leave the rest of the fields as is;
+   ```
+   {
+       "State":"{State}",
+       "ProblemID":"{ProblemID}",
+       "ProblemTitle":"{ProblemTitle}"
+   }
+   ```
+   You can customize to your taste, the only important thing is the `ProblemID` key. The webhook integration will not work without it. 6. `Alerting profile` - select the corresponding alerting profile 7. Leave the rest of the fields as is;
 6. Click **Save changes**
 
 ### Ingest data into Port

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/dynatrace.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/dynatrace.md
@@ -112,3 +112,153 @@ Done! any problem detected on your Dynatrace entity will trigger a webhook event
 In this example you will create a `dynatrace_entity` blueprint that ingests monitored entities from your Dynatrace account. You will then add some python script to make API calls to Dynatrace REST API and fetch data for your account.
 
 - [Code Repository Example](https://github.com/port-labs/example-dynatrace-entities)
+
+## Let's Test It
+
+This section includes a sample response data from Dynatrace. In addition, it includes the entity created from the resync event based on the Ocean configuration provided in the previous section.
+
+### Payload
+
+Here is an example of the payload structure from Dynatrace:
+
+<details>
+<summary>Problem response data</summary>
+
+```json showLineNumbers
+{
+  "affectedEntities": [
+    {
+      "entityId": {
+        "id": "string",
+        "type": "string"
+      },
+      "name": "string"
+    }
+  ],
+  "displayId": "string",
+  "endTime": 1574697669865,
+  "entityTags": [
+    {
+      "context": "CONTEXTLESS",
+      "key": "architecture",
+      "stringRepresentation": "architecture:x86",
+      "value": "x86"
+    },
+    {
+      "context": "ENVIRONMENT",
+      "key": "Infrastructure",
+      "stringRepresentation": "[ENVIRONMENT]Infrastructure:Linux",
+      "value": "Linux"
+    }
+  ],
+  "evidenceDetails": {
+    "details": [
+      {
+        "displayName": "Availability evidence",
+        "entity": {},
+        "evidenceType": "AVAILABILITY_EVIDENCE",
+        "groupingEntity": {},
+        "rootCauseRelevant": true,
+        "startTime": 1
+      },
+      {
+        "displayName": "User action evidence",
+        "entity": {},
+        "evidenceType": "USER_ACTION_EVIDENCE",
+        "groupingEntity": {},
+        "rootCauseRelevant": true,
+        "startTime": 1
+      }
+    ],
+    "totalCount": 1
+  },
+  "impactAnalysis": {
+    "impacts": [
+      {
+        "estimatedAffectedUsers": 1,
+        "impactType": "APPLICATION",
+        "impactedEntity": {}
+      }
+    ]
+  },
+  "impactLevel": "APPLICATION",
+  "impactedEntities": [{}],
+  "linkedProblemInfo": {
+    "displayId": "string",
+    "problemId": "string"
+  },
+  "managementZones": [
+    {
+      "id": "string",
+      "name": "HOST"
+    }
+  ],
+  "problemFilters": [
+    {
+      "id": "E2A930951",
+      "name": "BASELINE"
+    }
+  ],
+  "problemId": "06F288EE2A930951",
+  "recentComments": {
+    "comments": [
+      {
+        "authorName": "string",
+        "content": "string",
+        "context": "string",
+        "createdAtTimestamp": 1,
+        "id": "string"
+      }
+    ],
+    "nextPageKey": "AQAAABQBAAAABQ==",
+    "pageSize": 1,
+    "totalCount": 1
+  },
+  "rootCauseEntity": {},
+  "severityLevel": "AVAILABILITY",
+  "startTime": 1574697667547,
+  "status": "CLOSED",
+  "title": "title"
+}
+```
+
+</details>
+
+### Mapping Result
+
+The combination of the sample payload and the Ocean configuration generates the following Port entity:
+
+
+<details>
+<summary>Problem entity in Port</summary>
+
+```json showLineNumbers
+{
+  "identifier": "06F288EE2A930951",
+  "title": "title",
+  "blueprint": "dynatraceProblem",
+  "team": [],
+  "icon": "Dynatrace",
+  "properties": {
+    "entityTags": ["architecture:x86", "[ENVIRONMENT]Infrastructure:Linux"],
+    "evidenceDetails": ["Availability evidence", "User action evidence"],
+    "managementZones": ["HOST"],
+    "problemFilters": ["BASELINE"],
+    "severityLevel": "AVAILABILITY",
+    "status": "CLOSED",
+    "startTime": "2019-11-25T14:14:27Z",
+    "endTime": "2020-04-30T14:52:41Z"
+  },
+  "relations": {
+    "impactedEntities": ["HOST-06F288EE2A930951"],
+    "linkedProblemInfo": "06F288EE2A930951",
+    "rootCauseEntity": "HOST-06F288EE2A930951"
+  },
+  "createdAt": "2024-2-6T09:30:57.924Z",
+  "createdBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW",
+  "updatedAt": "2024-2-6T11:49:20.881Z",
+  "updatedBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW"
+}
+```
+
+</details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/dynatrace.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/dynatrace.md
@@ -228,7 +228,6 @@ Here is an example of the payload structure from Dynatrace:
 
 The combination of the sample payload and the Ocean configuration generates the following Port entity:
 
-
 <details>
 <summary>Problem entity in Port</summary>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/jenkins.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/jenkins.md
@@ -65,7 +65,6 @@ In order to view the different payloads and events available in Jenkins webhooks
 
 Done! any changes to a job or build process (queued, started, completed, finalized etc.) will trigger a webhook event to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.
 
-
 ## Let's Test It
 
 This section includes a sample response data from Jenkins. In addition, it includes the entity created from the resync event based on the Ocean configuration provided in the previous section.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/jenkins.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/jenkins.md
@@ -64,3 +64,126 @@ In order to view the different payloads and events available in Jenkins webhooks
 :::
 
 Done! any changes to a job or build process (queued, started, completed, finalized etc.) will trigger a webhook event to the webhook URL provided by Port. Port will parse the events according to the mapping and update the catalog entities accordingly.
+
+
+## Let's Test It
+
+This section includes a sample response data from Jenkins. In addition, it includes the entity created from the resync event based on the Ocean configuration provided in the previous section.
+
+### Payload
+
+Here is an example of the payload structure from Jenkins:
+
+<details>
+<summary>Job response data</summary>
+  
+```json showLineNumbers
+{
+  "_class" : "hudson.model.FreeStyleProject",
+  "displayName" : "Hello Job",
+  "fullName" : "Hello Job",
+  "name" : "Hello Job",
+  "url" : "http://localhost:8080/job/Hello%20Job/",
+  "buildable" : true,
+  "builds" : [
+    {
+      "_class" : "hudson.model.FreeStyleBuild",
+      "displayName" : "#2",
+      "duration" : 221,
+      "fullDisplayName" : "Hello Job #2",
+      "id" : "2",
+      "number" : 2,
+      "result" : "SUCCESS",
+      "timestamp" : 1700569094576,
+      "url" : "http://localhost:8080/job/Hello%20Job/2/"
+    },
+    {
+      "_class" : "hudson.model.FreeStyleBuild",
+      "displayName" : "#1",
+      "duration" : 2214,
+      "fullDisplayName" : "Hello Job #1",
+      "id" : "1",
+      "number" : 1,
+      "result" : "SUCCESS",
+      "timestamp" : 1700567994163,
+      "url" : "http://localhost:8080/job/Hello%20Job/1/"
+    }
+  ],
+  "color" : "blue"
+}
+```
+
+</details>
+
+<details>
+<summary>Build response data</summary>
+  
+```json showLineNumbers
+{
+  "_class" : "hudson.model.FreeStyleBuild",
+  "displayName" : "#2",
+  "duration" : 221,
+  "fullDisplayName" : "Hello Job #2",
+  "id" : "2",
+  "number" : 2,
+  "result" : "SUCCESS",
+  "timestamp" : 1700569094576,
+  "url" : "http://localhost:8080/job/Hello%20Job/2/"
+}
+```
+
+</details>
+
+### Mapping Result
+
+The combination of the sample payload and the Ocean configuration generates the following Port entity:
+
+<details>
+<summary>Job entity</summary>
+  
+```json showLineNumbers
+{
+  "identifier": "hello-job",
+  "title": "Hello Job",
+  "blueprint": "jenkinsJob",
+  "properties": {
+    "jobName": "Hello Job",
+    "url": "http://localhost:8080/job/Hello%20Job/",
+    "jobStatus": "passing",
+    "timestamp": "2023-09-08T14:58:14Z"
+  },
+  "relations": {},
+  "createdAt": "2023-12-18T08:37:21.637Z",
+  "createdBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW",
+  "updatedAt": "2023-12-18T08:37:21.637Z",
+  "updatedBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW"
+}
+```
+
+</details>
+
+<details>
+<summary>Build entity</summary>
+  
+```json showLineNumbers
+{
+  "identifier": "hello-job-2",
+  "title": "Hello Job #2",
+  "blueprint": "jenkinsBuild",
+  "properties": {
+    "buildStatus": "SUCCESS",
+    "buildUrl": "http://localhost:8080/job/Hello%20Job/2/",
+    "buildDuration": 221,
+    "timestamp": "2023-09-08T14:58:14Z"
+  },
+  "relations": {
+    "parentJob": "hello-job"
+  },
+  "createdAt": "2023-12-18T08:37:21.637Z",
+  "createdBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW",
+  "updatedAt": "2023-12-18T08:37:21.637Z",
+  "updatedBy": "hBx3VFZjqgLPEoQLp7POx5XaoB0cgsxW"
+}
+```
+
+</details>


### PR DESCRIPTION
# Description

Add "Let's test it" in all Ocean and Webhook Integrations 

## Updated docs pages

Please also include the path for the updated docs

- New Relic (`docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md`)
- Jenkins (`docs/build-your-software-catalog/sync-data-to-catalog/ci-cd/jenkins.md`), (`docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/jenkins.md`)
- Snyk (`docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk.md`)
- Dynatrace (`docs/build-your-software-catalog/sync-data-to-catalog/incident-management/__dynatrace.md`), (`docs/build-your-software-catalog/sync-data-to-catalog/webhook/examples/dynatrace.md`)