### PR TITLE
PORT-6657 - Open Slack Channel for Incident Management

### DIFF
--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/_category_.json
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "ArgoCD",
+    "position": 1
+  }
+  

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/sync-argocd-app.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/sync-argocd-app.md
@@ -21,8 +21,8 @@ Follow these steps to get started:
 
 1. Create the following GitHub Action secrets:
     1. `ARGOCD_TOKEN` - Argocd token [learn more](https://argo-cd.readthedocs.io/en/stable/developer-guide/api-docs/)
-    2. `PORT_CLIENT_ID` - Port Client ID [learn more](/build-your-software-catalog/sync-data-to-catalog/api/#get-api-token).
-    3. `PORT_CLIENT_SECRET` - Port Client Secret [learn more](/build-your-software-catalog/sync-data-to-catalog/api/#get-api-token).
+    2. `PORT_CLIENT_ID` - Port Client ID [learn more](/build-your-software-catalog/custom-integration/api/#get-api-token).
+    3. `PORT_CLIENT_SECRET` - Port Client Secret [learn more](/build-your-software-catalog/custom-integration/api/#get-api-token).
 
 2. Install Port's GitHub app by clicking [here](https://github.com/apps/getport-io/installations/new).
 

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/sync-argocd-app.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/sync-argocd-app.md
@@ -1,0 +1,209 @@
+---
+sidebar_position: 1
+---
+import Tabs from "@theme/Tabs"
+import TabItem from "@theme/TabItem"
+import PortTooltip from "/src/components/tooltip/tooltip.jsx";
+
+# Synchronize ArgoCD Application
+
+In the following guide, you are going to create a self-service action in Port that executes a [GitHub workflow](/create-self-service-experiences/setup-backend/github-workflow/github-workflow.md) to sync an argocd application.
+
+## Prerequisites
+1. This guide assumes that you already have a blueprint for an ArgoCD Application with some resources. If you haven't done so yet, create the blueprint by referring to this [guide](/build-your-software-catalog/sync-data-to-catalog/kubernetes/argocd#application) first.
+2. Prior knowledge of Port Actions is essential for following this guide. Learn more about them [here](/create-self-service-experiences/setup-ui-for-action/).
+3. A GitHub repository to contain your action resources i.e. the github workflow file.
+
+
+## Example - synchronizing argocd application
+
+Follow these steps to get started:
+
+1. Create the following GitHub Action secrets:
+    1. `ARGOCD_TOKEN` - Argocd token [learn more](https://argo-cd.readthedocs.io/en/stable/developer-guide/api-docs/)
+    2. `PORT_CLIENT_ID` - Port Client ID [learn more](/build-your-software-catalog/sync-data-to-catalog/api/#get-api-token).
+    3. `PORT_CLIENT_SECRET` - Port Client Secret [learn more](/build-your-software-catalog/sync-data-to-catalog/api/#get-api-token).
+
+2. Install Port's GitHub app by clicking [here](https://github.com/apps/getport-io/installations/new).
+
+3. Create Port action using the following JSON definition:
+
+:::note
+Make sure to replace the placeholders for GITHUB_ORG_NAME and GITHUB_REPO_NAME in your Port Action to match your GitHub environment.
+:::
+
+```json showLineNumbers
+[
+{
+  "identifier": "sync_application",
+  "title": "Sync Application",
+  "icon": "Argo",
+  "userInputs": {
+    "properties": {
+      "application_name": {
+        "title": "Application Name",
+        "description": "ArgoCD Application Name",
+        "icon": "Argo",
+        "type": "string",
+        "default": {
+          "jqQuery": ".entity.title"
+        }
+      },
+      "application_host": {
+        "icon": "Argo",
+        "title": "Application Host",
+        "description": "ArgoCD Application Host. e.g app.example.com",
+        "type": "string"
+      }
+    },
+    "required": [
+      "application_host",
+      "application_name"
+    ],
+    "order": [
+      "application_host",
+      "application_name"
+    ]
+  },
+  "invocationMethod": {
+    "type": "GITHUB",
+    "org": "<GITHUB_ORG_NAME>",
+    "repo": "<GITHUB_REPO_NAME>"
+    "workflow": "sync-argocd-app.yaml",
+    "omitUserInputs": false,
+    "omitPayload": false,
+    "reportWorkflowStatus": true
+  },
+  "trigger": "DAY-2",
+  "description": "Sync An ArgoCD Application",
+  "requiredApproval": false
+}  
+]
+```
+
+4. Create a workflow file under `.github/workflows/sync-argocd-app.yaml` with the following content:
+
+```yml showLineNumbers
+name: Sync ArgoCD Application
+on:
+  workflow_dispatch:
+    inputs:
+      application_name:
+        description: The ArgoCD Application Name. e.g. app.example.com
+        required: true
+      application_host:
+        description: The ArgoCD Application host.
+        required: true
+        type: string
+      port_payload:
+        required: true
+        description: >-
+          Port's payload, including details for who triggered the action and
+          general context (blueprint, run id, etc...)
+
+jobs:
+  sync-argocd-app:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log Executing Request to Sync Application
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "About to make a request to argocd server..."
+
+      - name: Sync ArgoCD Application
+        uses: omegion/argocd-actions@v1
+        with:
+          address: ${{ github.event.inputs.application_host }}
+          token: ${{ secrets.ARGOCD_TOKEN }}
+          action: sync
+          appName: ${{ github.event.inputs.application_name }}
+
+      - name: Log If Request Fails 
+        if: failure()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Request to sync argocd application failed ..."
+          
+      - name: Log Before Requesting for Synced Application
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Fetching data of synced application ..."
+
+      - name: Request for Synced Application
+        id: synced_application
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://${{github.event.inputs.application_host}}/api/v1/applications/${{github.event.inputs.application_name}}'
+          method: 'GET'
+          customHeaders: '{ "Content-Type": "application/json", "Authorization": "Bearer ${{secrets.ARGOCD_TOKEN}}" }'
+              
+      - name: Log Before Upserting Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Reporting the synced application back to port ..."
+    
+      - name: UPSERT Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          identifier: "${{ fromJson(steps.synced_application.outputs.response).metadata.uid }}"
+          title: "${{ fromJson(steps.synced_application.outputs.response).metadata.name }}"
+          blueprint: ${{ fromJson(inputs.port_payload).context.blueprint }}
+          properties: |-
+            {
+              "namespace": "${{ fromJson(steps.synced_application.outputs.response).metadata.namespace }}",
+              "gitRepo": "${{ fromJson(steps.synced_application.outputs.response).spec.source.repoURL }}",
+              "gitPath": "${{ fromJson(steps.synced_application.outputs.response).spec.source.path }}",
+              "destinationServer": "${{ fromJson(steps.synced_application.outputs.response).spec.destination.server }}",
+              "syncStatus": "${{ fromJson(steps.synced_application.outputs.response).status.sync.status }}",
+              "healthStatus": "${{ fromJson(steps.synced_application.outputs.response).status.health.status }}",
+              "createdAt": "${{ fromJson(steps.synced_application.outputs.response).metadata.creationTimestamp}}"
+            }
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: UPSERT
+          runId: ${{ fromJson(inputs.port_payload).context.runId }}
+
+      - name: Log If Upsetting Entity Fails 
+        if: failure()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Failed to upsert synced argocd application to port ..."
+          
+      - name: Log After Upserting Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Entity upserting was successful ✅"
+```
+
+5. Trigger the action from the [Self-service](https://app.getport.io/self-serve) tab of your Port application.

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/sync-argocd-app.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/sync-argocd-app.md
@@ -28,8 +28,10 @@ Follow these steps to get started:
 
 3. Create Port action using the following JSON definition:
 
+<details>
+<summary>Port Action: Sync ArgoCD Application </summary>
 :::note
-Make sure to replace the placeholders for GITHUB_ORG_NAME and GITHUB_REPO_NAME in your Port Action to match your GitHub environment.
+Replace the placeholders for GITHUB_ORG_NAME and GITHUB_REPO_NAME in your Port Action to match your GitHub environment.
 :::
 
 ```json showLineNumbers
@@ -80,8 +82,12 @@ Make sure to replace the placeholders for GITHUB_ORG_NAME and GITHUB_REPO_NAME i
 }  
 ]
 ```
+</details>
 
 4. Create a workflow file under `.github/workflows/sync-argocd-app.yaml` with the following content:
+
+<details>
+ <summary>GitHub Workflow </summary>
 
 ```yml showLineNumbers
 name: Sync ArgoCD Application
@@ -205,5 +211,6 @@ jobs:
           runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
           logMessage: "Entity upserting was successful ✅"
 ```
+</details>
 
 5. Trigger the action from the [Self-service](https://app.getport.io/self-serve) tab of your Port application.

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/open-slack-channel.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/open-slack-channel.md
@@ -1,0 +1,583 @@
+import PortTooltip from "/src/components/tooltip/tooltip.jsx";
+
+# Open Slack Channel
+
+## Overview
+
+In this guide, we will demonstrate how to create a self-service action in Port that not only automates the creation of a new Slack channel for a service but also includes the option to add members during the channel's setup.
+
+## Prerequisites
+1. [Create a slack app](https://api.slack.com/start/quickstart#creating) and install it on a workspace.
+2. Generate a [Slack Bot User Oauth Token](https://api.slack.com/apps/A06PVJZQBHB/oauth?success=1) with permissions to create a new channel and invite users of the slack workspace to the slack channel.
+    * [Bot User Scopes](https://api.slack.com/start/quickstart#scopes):
+      * [Create channel](https://api.slack.com/methods/conversations.invite) (**Required**) : 
+      `channels:manage`
+      `groups:write`
+      `im:write`
+      `mpim:write`
+      * [Find a user with an email address](https://api.slack.com/methods/users.lookupByEmail) (**Optional**) : 
+      `users:read.email`
+      * [Invite users to channel](https://api.slack.com/methods/conversations.invite) (**Optional**) : 
+        `channels:write.invites`
+        `groups:write.invites`
+        `mpim:write.invites`
+        `channels:manage`
+        `groups:write`
+        `im:write`
+        `mpim:write`    
+:::note
+Without scopes for `Find a user with an email address` and `Invite users to channel`, the channel will be created but users will not be added to it.
+:::
+3. [Port's GitHub app](https://github.com/apps/getport-io) needs to be installed.
+
+## Steps
+1. Create the following GitHub action secrets
+* `BOT_USER_OAUTH_TOKEN` - [Slack Bot User Oauth Token](https://api.slack.com/authentication/token-types#bot) generated for the slack app.
+* `PORT_CLIENT_ID` - Your port [client id](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials).
+* `PORT_CLIENT_SECRET` - Your port [client secret](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials).
+
+2. Create a <PortTooltip id="blueprint">blueprint</PortTooltip> for the service with the following JSON definition:
+
+<details>
+   <summary><b>Service Blueprint (Click to expand)</b></summary>
+
+```json showLineNumbers
+{
+  "identifier": "service",
+  "title": "Service",
+  "icon": "Github",
+  "teamInheritance": {
+    "path": "team"
+  },
+  "schema": {
+    "properties": {
+      "readme": {
+        "title": "README",
+        "type": "string",
+        "format": "markdown",
+        "icon": "Book"
+      },
+      "language": {
+        "icon": "Git",
+        "type": "string",
+        "title": "Language",
+        "enum": [
+          "GO",
+          "Python",
+          "Node",
+          "React"
+        ],
+        "enumColors": {
+          "GO": "red",
+          "Python": "green",
+          "Node": "blue",
+          "React": "yellow"
+        }
+      },
+      "tier": {
+        "icon": "DefaultProperty",
+        "title": "Tier",
+        "description": "Service Tiers indicate the significance or importance of a Service for business operations",
+        "type": "string",
+        "enum": [
+          "Mission Critical",
+          "Customer Facing",
+          "Internal Service",
+          "Other"
+        ],
+        "enumColors": {
+          "Mission Critical": "turquoise",
+          "Customer Facing": "green",
+          "Internal Service": "darkGray",
+          "Other": "yellow"
+        }
+      },
+      "code_owners": {
+        "title": "Code owners",
+        "description": "This service's code owners",
+        "type": "array",
+        "icon": "TwoUsers"
+      },
+      "resource_definitions": {
+        "title": "Resource definitions",
+        "description": "A link to the service's resource definitions",
+        "icon": "Terraform",
+        "type": "string",
+        "format": "url"
+      },
+      "type": {
+        "title": "Type",
+        "description": "This service's type",
+        "type": "string",
+        "enum": [
+          "Backend",
+          "Frontend",
+          "Library"
+        ],
+        "enumColors": {
+          "Backend": "purple",
+          "Frontend": "pink",
+          "Library": "green"
+        },
+        "icon": "DefaultProperty"
+      },
+      "lifecycle": {
+        "title": "Lifecycle",
+        "type": "string",
+        "enum": [
+          "Production",
+          "Experimental",
+          "Deprecated"
+        ],
+        "enumColors": {
+          "Production": "green",
+          "Experimental": "yellow",
+          "Deprecated": "red"
+        },
+        "icon": "DefaultProperty"
+      },
+      "require_approval_count": {
+        "title": "Require approvals",
+        "type": "number",
+        "icon": "DefaultProperty"
+      },
+      "is_protected": {
+        "title": "Is branch protected",
+        "type": "boolean",
+        "icon": "DefaultProperty"
+      },
+      "require_code_owner_review": {
+        "title": "Require code owner review",
+        "type": "boolean",
+        "icon": "DefaultProperty"
+      },
+      "locked_in_prod": {
+        "icon": "DefaultProperty",
+        "title": "Locked in Prod",
+        "type": "boolean",
+        "default": false
+      },
+      "last_push": {
+        "icon": "GitPullRequest",
+        "title": "Last push",
+        "description": "Last commit to the main branch",
+        "type": "string",
+        "format": "date-time"
+      },
+      "required_approvals": {
+        "icon": "Lock",
+        "title": "Required approvals",
+        "type": "number",
+        "description": "Number of required approvals for a PR to be merged to main branch"
+      },
+      "locked_reason_prod": {
+        "icon": "DefaultProperty",
+        "title": "Locked Reason Prod",
+        "type": "string"
+      },
+      "locked_reason_test": {
+        "title": "Locked Reason Test",
+        "type": "string",
+        "icon": "DefaultProperty"
+      },
+      "locked_in_test": {
+        "title": "Locked in Test",
+        "type": "boolean",
+        "default": false,
+        "icon": "DefaultProperty"
+      },
+      "runbooks": {
+        "title": "Runbooks",
+        "type": "array",
+        "icon": "Misconfiguration",
+        "items": {
+          "type": "string",
+          "format": "url"
+        }
+      },
+      "monitor_dashboards": {
+        "title": "Monitor Dashboards",
+        "type": "array",
+        "icon": "Grafana",
+        "items": {
+          "type": "string",
+          "format": "url"
+        }
+      },
+      "spec": {
+        "title": "Spec",
+        "type": "string",
+        "description": "Spec in Prod",
+        "icon": "Swagger",
+        "format": "yaml",
+        "spec": "open-api"
+      },
+      "last_contributer": {
+        "icon": "TwoUsers",
+        "title": "Last contributer",
+        "type": "string",
+        "format": "user"
+      },
+      "url": {
+        "title": "URL",
+        "format": "url",
+        "type": "string",
+        "icon": "Link"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {
+    "on_call": {
+      "path": "pager_duty_service.oncall"
+    },
+    "coverage": {
+      "path": "sonar_qube_project.coverage"
+    },
+    "sonar_qube_vulnerabilities": {
+      "path": "sonar_qube_project.numberOfVulnerabilities"
+    },
+    "security_hotspots": {
+      "path": "sonar_qube_project.numberOfHotSpots"
+    },
+    "prod_health": {
+      "path": "prod_runtime.healthStatus"
+    },
+    "synced_in_prod": {
+      "path": "prod_runtime.syncStatus"
+    },
+    "test_health": {
+      "path": "test_runtime.healthStatus"
+    },
+    "synced_in_test": {
+      "path": "test_runtime.syncStatus"
+    },
+    "health_status": {
+      "path": "dev_runtime.healthStatus"
+    },
+    "sync_status": {
+      "path": "dev_runtime.syncStatus"
+    },
+    "status": {
+      "path": "pager_duty_service.status"
+    }
+  },
+  "calculationProperties": {
+    "freshness": {
+      "title": "Freshness",
+      "icon": "Clock",
+      "calculation": "((now - ((.properties.last_push) | fromdate)) / 86400) | floor",
+      "type": "number",
+      "colorized": false,
+      "colors": {}
+    },
+    "slack": {
+      "title": "Slack",
+      "icon": "Slack",
+      "calculation": "\"https://slack.com/\" + .identifier",
+      "type": "string"
+    }
+  },
+  "aggregationProperties": {},
+  "relations": {
+    "sonar_qube_project": {
+      "title": "SonarQube Project",
+      "target": "sonarQubeProject",
+      "required": false,
+      "many": false
+    },
+    "prod_runtime": {
+      "title": "Prod runtime",
+      "description": "The service's prod runtime",
+      "target": "running_service",
+      "required": false,
+      "many": false
+    },
+    "snyk_project": {
+      "title": "Snyk Project",
+      "target": "snykProject",
+      "required": false,
+      "many": false
+    },
+    "ecr_repo": {
+      "title": "ECR Repo",
+      "target": "ecrRepository",
+      "required": false,
+      "many": false
+    },
+    "githubTeams": {
+      "title": "GitHub teams",
+      "target": "githubTeam",
+      "required": false,
+      "many": true
+    },
+    "test_runtime": {
+      "title": "Test runtime",
+      "description": "The service's test runtime",
+      "target": "running_service",
+      "required": false,
+      "many": false
+    },
+    "pager_duty_service": {
+      "title": "PagerDuty Service",
+      "description": "Corresponding Pagerduty Service",
+      "target": "pagerdutyService",
+      "required": false,
+      "many": false
+    },
+    "consumes_api": {
+      "title": "Consumes API",
+      "target": "api",
+      "required": false,
+      "many": true
+    },
+    "dora_last_7_days": {
+      "title": "DORA last 7 days",
+      "target": "doraMetrics",
+      "required": false,
+      "many": false
+    },
+    "team": {
+      "title": "Team",
+      "target": "idp_team",
+      "required": false,
+      "many": false
+    },
+    "domain": {
+      "title": "Domain",
+      "description": "The domain this service belongs to",
+      "target": "domain",
+      "required": false,
+      "many": false
+    },
+    "provides_api": {
+      "title": "Provides API",
+      "target": "api",
+      "required": false,
+      "many": false
+    },
+    "dev_runtime": {
+      "title": "Dev Runtime",
+      "target": "running_service",
+      "required": false,
+      "many": false
+    },
+    "dora_last_30_days": {
+      "title": "DORA last 30 days",
+      "target": "doraMetrics",
+      "required": false,
+      "many": false
+    }
+  }
+}
+```
+</details>
+
+3. Create an action in Port on the service blueprint
+:::tip Action usage
+This action is utilized within the Service blueprint in Port and can be triggered manually via self service action or the catalog
+:::
+
+<details>
+<summary><b>Open Slack Channel Action (Click to expand)</b></summary>
+:::tip
+- `<GITHUB-ORG>` - your GitHub organization or user name.
+- `<GITHUB-REPO-NAME>` - your GitHub repository name.
+:::
+
+```json showLineNumbers
+{
+  "identifier": "open_slack_channel",
+  "title": "Open Slack Channel",
+  "icon": "Slack",
+  "userInputs": {
+    "properties": {
+      "channel_name": {
+        "icon": "Slack",
+        "title": "Channel Name",
+        "type": "string",
+        "default": {
+          "jqQuery": "\"incident-\"+.entity.title"
+        }
+      },
+      "is_private": {
+        "description": "Create a private channel instead of a public one",
+        "title": "Is Private",
+        "type": "boolean",
+        "default": false,
+        "icon": "Slack"
+      },
+      "team_id": {
+        "description": "Encoded team id to create the channel in, required if org token is used",
+        "title": "Team ID",
+        "icon": "Slack",
+        "type": "string"
+      },
+      "members": {
+        "items": {
+          "type": "string"
+        },
+        "title": "Members",
+        "icon": "Slack",
+        "type": "array",
+        "description": "Add members manually to the channel.",
+        "default": {
+          "jqQuery": ".entity.properties.code_owners"
+        }
+      }
+    },
+    "required": [
+      "members"
+    ],
+    "order": [
+      "channel_name",
+      "members",
+      "is_private",
+      "team_id"
+    ]
+  },
+  "invocationMethod": {
+    "type": "GITHUB",
+    "org": "<GITHUB-ORG>",
+    "repo": "<GITHUB-REPO-NAME>",
+    "workflow": "open-slack-channel.yaml",
+    "omitUserInputs": false,
+    "omitPayload": false,
+    "reportWorkflowStatus": true
+  },
+  "trigger": "DAY-2",
+  "requiredApproval": false
+}
+```
+
+</details>
+
+4. Create a workflow file under `.github/workflows/open-slack-channel.yaml` using the workflow:
+
+<details>
+<summary><b>Open Slack Channel (Click to expand)</b></summary>
+
+```yaml showLineNumbers
+
+name: Open Slack Channel
+on:
+  workflow_dispatch:
+    inputs:
+      channel_name:
+        description: Name of the public or private channel to create.
+        required: true
+        type: string
+      is_private:
+        description: Create a private channel instead of a public one.
+        required: false
+        type: boolean
+      team_id:
+        description: Encoded team ID to create the channel in, required if org token is used.
+        type: string
+        required: false
+      members:
+        description: Add members manually to the channel.
+        type: array
+        required: false
+      port_payload:
+        description: Port's payload, including details for who triggered the action and general context (blueprint, run ID, etc...).
+        required: true
+
+jobs:
+  open-slack-channel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log Executing Request to Open Channel
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ fromJson(github.event.inputs.port_payload).context.runId }}
+          logMessage: "About to create a conversation channel in slack..."
+
+      - name: Create Slack Channel
+        id: create_channel
+        env:
+          SLACK_TOKEN: ${{ secrets.BOT_USER_OAUTH_TOKEN }}
+        run: |
+          response=$(curl -s -X POST "https://slack.com/api/conversations.create" \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data "{\"name\": \"${{ github.event.inputs.channel_name }}\",\"is_private\": ${{ github.event.inputs.is_private }} }")
+          
+          echo "API Response: $response"
+          
+          if [[ "$(echo $response | jq -r '.ok')" == "true" ]]; then
+            channel_id=$(echo $response | jq -r '.channel.id')
+            echo "Channel ID: $channel_id"
+            echo "CHANNEL_ID=$channel_id" >> $GITHUB_ENV
+      
+          else
+            echo "Failed to create Slack channel. Channel ID is null."
+            error=$(echo $response | jq -r '.error')
+            error_message="${error//_/ }"
+            echo "Error: $error_message"
+            echo "CREATE_CHANNEL_ERROR=$error_message" >> $GITHUB_ENV
+            exit 1
+          fi
+
+      - name: Log If Create Channel Request Fails
+        if: failure()
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ fromJson(github.event.inputs.port_payload).context.runId }}
+          logMessage: "Failed to create slack channel: ${{env.CREATE_CHANNEL_ERROR}} ❌"
+
+      - name: Log If Create Channel Request is Successful
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ fromJson(github.event.inputs.port_payload).context.runId }}
+          logMessage: "Channel created successfully, channel Id: ${{env.CHANNEL_ID}} ✅"
+  
+      - name: Checkout code
+        uses: actions/checkout@v2
+        
+      - name: Add Members to Slack Channel
+        id: add_members
+        if: success()
+        env:
+          SLACK_TOKEN: ${{ secrets.BOT_USER_OAUTH_TOKEN }}
+          CHANNEL_ID: ${{env.CHANNEL_ID}}
+          CLIENT_ID: ${{ secrets.PORT_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.PORT_CLIENT_SECRET }}
+          RUN_ID: ${{ fromJson(github.event.inputs.port_payload).context.runId }}
+          MEMBER_EMAILS: ${{ toJSON(github.event.inputs.members) }}
+        run: |
+          cd slack
+          chmod +x add-members-to-channel.sh
+          bash add-members-to-channel.sh "$SLACK_TOKEN" "$CHANNEL_ID" "$CLIENT_ID" "$CLIENT_SECRET" "$RUN_ID" "$MEMBER_EMAILS"
+
+      - name: Log Successful Action
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{ fromJson(github.event.inputs.port_payload).context.runId }}
+          logMessage: "Successfully opened slack channel: ${{env.CHANNEL_ID}} ✅"
+```
+</details>
+
+5. Create the following bash script (`add-members-to-channel.sh`) in `slack` folder at the root of your GitHub repository:
+
+6. Trigger the action from Port's [Self Service hub](https://app.getport.io/self-serve)
+
+7. Done! wait for the slack channel to be created.
+
+Congrats 🎉 You've successfully opened a slack channel from Port 🔥


### PR DESCRIPTION
# Description

This guide demonstrates how to create a self-service action in Port that not only automates the creation of a new Slack channel for a service but also includes the option to add members during the channel's setup.

## Added docs pages

Please also include the path for the added docs

- Resource Path (`/create-self-service-experiences/setup-backend/github-workflow/examples/open-slack-channel`)