### PR TITLE
PORT 7470 | Upsert Created EC2 Instance to Port

### DIFF
--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/AWS/create-an-ec2-instance.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/AWS/create-an-ec2-instance.md
@@ -8,8 +8,14 @@ import PortTooltip from "/src/components/tooltip/tooltip.jsx";
 
 In the following guide, you are going to create a self-service action in Port that executes a [GitHub workflow](/create-self-service-experiences/setup-backend/github-workflow/github-workflow.md) to create an EC2 Instance in AWS using Terraform templates.
 
-## Prerequisites
+:::tip Prerequisites
+1. Prior knowledge of Port Actions is essential for following this guide. [Learn more](http://localhost:4000/create-self-service-experiences/setup-ui-for-action/).
+2. A GitHub repository to contain your action resources i.e. the github workflow file.
+3. An AWS Account or IAM user with permission to create access keys. [Learn more](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
+4. An SSH Key Pair to connect with the provisioned instance. [Learn more](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html#having-ec2-create-your-key-pair)
+:::
 
+## Steps
 1. Create the following GitHub Action secrets:
     * Create the following Port credentials:
         * `PORT_CLIENT_ID` - Port Client ID [learn more](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#get-api-token)
@@ -17,50 +23,29 @@ In the following guide, you are going to create a self-service action in Port th
         * Install the Ports GitHub app from [here](https://github.com/apps/getport-io/installations/new).
     
     * Create the following AWS Cloud credentials:   
-        :::tip Follow this [guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html#having-ec2-create-your-key-pair) to create an SSH key pair to connect with the provisioned instance.
-        :::
         * `TF_USER_AWS_KEY` - an aws access key with the right iam permission to create an ec2 instance [learn more](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
         * `TF_USER_AWS_SECRET` - an aws access key secret with permission to create an ec2 instance [learn more](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
         * `TF_USER_AWS_REGION` - the aws region where you would like to provision your ec2 instance.
 
-## Steps
+2. Install Port's GitHub app by clicking [here](https://github.com/apps/getport-io/installations/new).
 
-1. Install Port's GitHub app by clicking [here](https://github.com/apps/getport-io/installations/new).
+3. Create a <PortTooltip id="blueprint">blueprint</PortTooltip> in Port for EC2 Instance.
 
-2. Create a <PortTooltip id="blueprint">blueprint</PortTooltip> in Port for EC2 Instance
 <details>
-   <summary>Port Blueprint: EC2 Instance</summary>
+   <summary><b>Port Blueprint: EC2 Instance</b></summary>
 
 ```json showLineNumbers
-
 {
   "identifier": "ec2Instance",
-  "description": "This blueprint represents an AWS EC2 instance in our software catalog",
+  "description": "This blueprint represents an AWS EC2 instance in our software catalog.",
   "title": "EC2 Instance",
   "icon": "EC2",
   "schema": {
     "properties": {
-      "architecture": {
+      "instance_state": {
         "type": "string",
-        "title": "Architecture",
-        "enum": ["i386", "x86_64", "arm64", "x86_64_mac", "arm64_mac"]
-      },
-      "availabilityZone": {
-        "type": "string",
-        "title": "Availability Zone"
-      },
-      "link": {
-        "type": "string",
-        "title": "Link",
-        "format": "url"
-      },
-      "platform": {
-        "type": "string",
-        "title": "Platform"
-      },
-      "state": {
-        "type": "string",
-        "title": "State",
+        "title": "Instance State",
+        "description": "The state of the EC2 instance (e.g., running, stopped).",
         "enum": [
           "pending",
           "running",
@@ -78,41 +63,74 @@ In the following guide, you are going to create a self-service action in Port th
           "terminated": "red"
         }
       },
-      "tags": {
+      "instance_type": {
+        "type": "string",
+        "title": "Instance Type",
+        "description": "The type of EC2 instance (e.g., t2.micro, m5.large)."
+      },
+      "availability_zone": {
+        "type": "string",
+        "title": "Availability Zone",
+        "description": "The Availability Zone where the EC2 instance is deployed."
+      },
+      "public_dns": {
+        "type": "string",
+        "title": "Public DNS",
+        "description": "The public DNS name assigned to the EC2 instance."
+      },
+      "public_ip": {
+        "type": "string",
+        "title": "Public IP Address",
+        "description": "The public IP address assigned to the EC2 instance."
+      },
+      "private_dns": {
+        "type": "string",
+        "title": "Private DNS",
+        "description": "The private DNS name assigned to the EC2 instance within its VPC."
+      },
+      "private_ip": {
+        "type": "string",
+        "title": "Private IP Address",
+        "description": "The private IP address assigned to the EC2 instance within its VPC."
+      },
+      "monitoring": {
+        "type": "boolean",
+        "title": "Monitoring",
+        "description": "Indicates if detailed monitoring is enabled for the EC2 instance."
+      },
+      "security_group_ids": {
         "type": "array",
-        "title": "Tags"
+        "title": "Security Group IDs",
+        "description": "The list of security group IDs assigned to the EC2 instance."
       },
-      "type": {
+      "key_name": {
         "type": "string",
-        "title": "Instance Type"
-      },
-      "vpcId": {
-        "type": "string",
-        "title": "VPC ID"
+        "title": "Key Name",
+        "description": "The name of the key pair associated with the EC2 instance."
       }
     },
     "required": []
   },
   "mirrorProperties": {},
   "calculationProperties": {},
+  "aggregationProperties": {},
   "relations": {}
 }
 ```
 </details>
 
-3. Create a Port action in the [self-service page](https://app.getport.io/self-serve) or with the following JSON definition for the `EC2 Instance` blueprint:
+4. Create a Port action in the [self-service page](https://app.getport.io/self-serve) or with the following JSON definition for the `EC2 Instance` blueprint:
 
 <details>
-  <summary>Port Action: Create EC2 Instance</summary>
-   :::tip
+  <summary> <b> Port Action: Create EC2 Instance </b> </summary>
+:::tip
 - `<GITHUB-ORG>` - your GitHub organization or user name.
 - `<GITHUB-REPO-NAME>` - your GitHub repository name.
 :::
 
 ```json showLineNumbers
-[
 {
-  "identifier": "create_an_ec_2_instance",
+  "identifier": "create_an_ec2_instance",
   "title": "Create An EC2 Instance",
   "icon": "EC2",
   "userInputs": {
@@ -167,14 +185,153 @@ In the following guide, you are going to create a self-service action in Port th
   "description": "Create An EC2 Instance from Port",
   "requiredApproval": false
 }
-]
 ```
 </details>
 
-4. Create a workflow file under .github/workflows/create-an-ec2-instance.yaml with the following content:
+5. Create a folder in a directory of your choice within your github repository to host the terraform template files.
+
+6. Create the following terraform templates ( `main.tf`, `variables.tf` and `outputs.tf` ) within the created folder.
 
 <details>
-<summary>GitHub workflow script</summary>
+  <summary><b>main.tf</b></summary>
+
+```hcl showLineNumbers title="main.tf"
+data "aws_ami" "ubuntu" {
+    most_recent = true
+
+    filter {
+        name   = "name"
+        values = ["ubuntu/images/hvm-ssd/*20.04-amd64-server-*"]
+    }
+
+    filter {
+        name   = "virtualization-type"
+        values = ["hvm"]
+    }
+    
+    owners = ["099720109477"] # Canonical
+}
+
+provider "aws" {
+  region  = var.aws_region
+}
+
+resource "aws_instance" "app_server" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = var.ec2_instance_type
+  key_name      = var.pem_key_name
+
+  tags = {
+    Name = var.ec2_name
+  }
+}
+
+```
+</details>
+
+<details>
+  <summary><b>variables.tf</b></summary>
+
+```hcl showLineNumbers title = "variables.tf"
+variable "ec2_name" {
+  type = string
+}
+
+variable "pem_key_name" {
+  type = string
+}
+
+variable "aws_region" {
+  type = string
+}
+
+variable "ec2_instance_type" {
+  type = string
+}
+```
+</details>
+
+<details>
+  <summary><b>outputs.tf</b></summary>
+
+```hcl showLineNumbers title="outputs.tf"
+
+output "instance_id" {
+  description = "The unique identifier for the provisioned EC2 instance."
+  value       = aws_instance.app_server.id
+}
+
+output "instance_state" {
+  description = "The state of the EC2 instance (e.g., running, stopped)."
+  value       = aws_instance.app_server.instance_state
+}
+
+output "instance_type" {
+  description = "The type of EC2 instance (e.g., t2.micro, m5.large)."
+  value       = aws_instance.app_server.instance_type
+}
+
+output "availability_zone" {
+  description = "The Availability Zone where the EC2 instance is deployed."
+  value       = aws_instance.app_server.availability_zone
+}
+
+output "public_dns" {
+  description = "The public DNS name assigned to the EC2 instance."
+  value       = aws_instance.app_server.public_dns
+}
+
+output "public_ip" {
+  description = "The public IP address assigned to the EC2 instance."
+  value       = aws_instance.app_server.public_ip
+}
+
+output "private_dns" {
+  description = "The private DNS name assigned to the EC2 instance within its VPC."
+  value       = aws_instance.app_server.private_dns
+}
+
+output "private_ip" {
+  description = "The private IP address assigned to the EC2 instance within its VPC."
+  value       = aws_instance.app_server.private_ip
+}
+
+output "monitoring" {
+  description = "Indicates if detailed monitoring is enabled for the EC2 instance."
+  value       = aws_instance.app_server.monitoring
+}
+
+output "security_group_ids" {
+  description = "The list of security group IDs assigned to the EC2 instance."
+  value       = aws_instance.app_server.vpc_security_group_ids
+}
+
+output "key_name" {
+  description = "The name of the key pair associated with the EC2 instance."
+  value       = aws_instance.app_server.key_name
+}
+
+output "subnet_id" {
+  description = "The ID of the subnet to which the instance is attached."
+  value       = aws_instance.app_server.subnet_id
+}
+
+output "tags" {
+  description = "A map of tags assigned to the resource."
+  value       = aws_instance.app_server.tags
+}
+```
+</details>
+
+
+7. Create a `Github Workflow` file under `.github/workflows/create-an-ec2-instance.yaml` with the following content:
+
+<details>
+<summary><b>GitHub workflow</b></summary>
+
+:::tip 
+  Replace `<TERRAFORM-TEMPLATE-DIR>` with the directory created to host your terraform templates.
+:::
 
 ```yml showLineNumbers title="create-an-ec2-instance.yaml"
 name: Provision AN EC2 Instance
@@ -238,11 +395,31 @@ jobs:
           TF_VAR_aws_region: "${{ secrets.TF_USER_AWS_REGION }}"
           TF_VAR_ec2_instance_type: "${{ github.event.inputs.ec2_instance_type}}"
         run: |
-          cd terraform
+          cd <TERRAFORM-TEMPLATE-DIR>
           terraform init
           terraform validate
           terraform plan 
           terraform apply -auto-approve
+
+      - name: Set Outputs
+        id: set_outputs
+        run: |
+          cd <TERRAFORM-TEMPLATE-DIR>
+          echo "instance_id=$(terraform output -raw instance_id)" >> $GITHUB_ENV
+          echo "instance_state=$(terraform output -raw instance_state)" >> $GITHUB_ENV
+          echo "instance_type=$(terraform output -raw instance_type)" >> $GITHUB_ENV
+          echo "availability_zone=$(terraform output -raw availability_zone)" >> $GITHUB_ENV
+          echo "public_dns=$(terraform output -raw public_dns)" >> $GITHUB_ENV
+          echo "public_ip=$(terraform output -raw public_ip)" >> $GITHUB_ENV
+          echo "private_dns=$(terraform output -raw private_dns)" >> $GITHUB_ENV
+          echo "private_ip=$(terraform output -raw private_ip)" >> $GITHUB_ENV
+          echo "monitoring=$(terraform output -raw monitoring)" >> $GITHUB_ENV
+          security_group_ids_json=$(terraform output -json security_group_ids | jq -c .)
+          echo "security_group_ids=$security_group_ids_json" >> $GITHUB_ENV
+          echo "key_name=$(terraform output -raw key_name)" >> $GITHUB_ENV
+          echo "subnet_id=$(terraform output -raw subnet_id)" >> $GITHUB_ENV
+          tags=$(terraform output -json tags | jq -c .)
+          echo "tags=$tags" >> $GITHUB_ENV
 
       - name: Create a log message
         uses: port-labs/port-github-action@v1
@@ -254,70 +431,57 @@ jobs:
           logMessage: |
               EC2 Instance created successfully ✅
 
+     - name: Report Created Instance to Port
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Upserting created EC2 Instance to Port ... "
+          
+      - name: UPSERT EC2 Instance Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          identifier: "${{ steps.display_outputs.outputs.instance_id }}"
+          title: "${{ inputs.ec2_name }}"
+          blueprint: ec2Instance
+          properties: |-
+            {
+              "instance_state": "${{ env.instance_state }}",
+              "instance_type": "${{ env.instance_type }}",
+              "availability_zone": "${{ env.availability_zone }}",
+              "public_dns": "${{ env.public_dns }}",
+              "public_ip": "${{ env.public_ip }}",
+              "private_dns": "${{ env.private_dns }}",
+              "private_ip": "${{ env.private_ip }}",
+              "monitoring": ${{ env.monitoring }},
+              "security_group_ids": ${{ env.security_group_ids }},
+              "key_name": "${{ env.key_name }}",
+              "subnet_id": "${{ env.subnet_id }}",
+              "tags": ${{ env.tags }}
+            }
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: UPSERT
+          runId: ${{ fromJson(inputs.port_payload).context.runId }}
+
+
+      - name: Log After Upserting Entity
+        uses: port-labs/port-github-action@v1
+        with:
+          clientId: ${{ secrets.PORT_CLIENT_ID }}
+          clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
+          baseUrl: https://api.getport.io
+          operation: PATCH_RUN
+          runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
+          logMessage: "Entity upserting was successful ✅"
 ```
 </details>
 
-5. Create the following terraform templates ( main.tf and variables.tf ) in `terraform` folder at the root of your GitHub repository:
 
-<details>
-  <summary><b>main.tf</b></summary>
-
-```hcl showLineNumbers title="main.tf"
-data "aws_ami" "ubuntu" {
-    most_recent = true
-
-    filter {
-        name   = "name"
-        values = ["ubuntu/images/hvm-ssd/*20.04-amd64-server-*"]
-    }
-
-    filter {
-        name   = "virtualization-type"
-        values = ["hvm"]
-    }
-    
-    owners = ["099720109477"] # Canonical
-}
-
-provider "aws" {
-  region  = var.aws_region
-}
-
-resource "aws_instance" "app_server" {
-  ami           = data.aws_ami.ubuntu.id
-  instance_type = var.ec2_instance_type
-  key_name      = var.pem_key_name
-
-  tags = {
-    Name = var.ec2_name
-  }
-}
-
-```
-</details>
-
-<details>
-  <summary><b>variables.tf</b></summary>
-
-```hcl showLineNumbers title = "variables.tf"
-variable "ec2_name" {
-  type = string
-}
-
-variable "pem_key_name" {
-  type = string
-}
-
-variable "aws_region" {
-  type = string
-}
-
-variable "ec2_instance_type" {
-  type = string
-}
-```
-</details>
-
-6. Trigger the action from Port's [Self Serve](https://app.getport.io/self-serve)
+8. Trigger the action from Port's [Self Serve](https://app.getport.io/self-serve)
 
 Congrats 🎉 You've created your instance in EC2 from Port!


### PR DESCRIPTION
# Description

This update extends the capabilities of  `PORT ACTION` to upsert the created EC2 Instance to Port
![image](https://github.com/port-labs/port-docs/assets/85971733/af608da7-944c-473a-8e10-614312621dfd)


## Updated docs pages

- Resource Path (`/create-self-service-experiences/setup-backend/github-workflow/examples/AWS/create-an-ec2-instance`)