### PR TITLE
Using express.json to get the request body as JSON

### DIFF
--- a/docs/create-self-service-experiences/setup-backend/webhook/local-debugging-webhook.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/local-debugging-webhook.md
@@ -319,6 +319,7 @@ Inside this folder create an `index.js` file and paste the following:
 const { createHmac } = require("crypto");
 const express = require("express");
 const app = express();
+app.use(express.json());
 const port = 3000;
 
 app.post("/webhooks", (request, response) => {

--- a/docs/create-self-service-experiences/setup-backend/webhook/local-debugging-webhook.md
+++ b/docs/create-self-service-experiences/setup-backend/webhook/local-debugging-webhook.md
@@ -331,7 +331,7 @@ app.post("/webhooks", (request, response) => {
     .digest("base64");
 
   if (signed !== request.headers["x-port-signature"].split(",")[1]) {
-    throw new Error("Invalid singature");
+    throw new Error("Invalid signature");
   }
 
   // You can put any custom logic here


### PR DESCRIPTION
# Description

@dhatcher42 was trying to follow the Debugging Webhooks locally guide, and was getting an error during the validation of the webhook request step. The validation error occurs due to the body of the request being undefined since we're not using any express middle-ware to read it.

## Updated docs pages
Debugging Webhooks locally - /create-self-service-experiences/setup-backend/webhook/local-debugging-webhook/#creating-a-small-example-server-in-nodejs
