### PR TITLE
PORT-7714 | Update Azure Devops docs with project mapping and blueprint

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-project/_azuredevops_exporter_example_project_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-project/_azuredevops_exporter_example_project_blueprint.mdx
@@ -1,0 +1,53 @@
+  <details>
+<summary>Project blueprint</summary>
+
+```json showLineNumbers
+
+  {
+    "identifier": "project",
+    "title": "Project",
+    "icon": "AzureDevops",
+    "schema": {
+      "properties": {
+        "state": {
+          "title": "State",
+          "type": "string",
+          "icon": "AzureDevops",
+          "description": "The current lifecycle state of the project."
+        },
+        "revision": {
+          "title": "Revision",
+          "type": "string",
+          "icon": "AzureDevops",
+          "description": "The revision number, indicating how many times the project configuration has been updated."
+        },
+        "visibility": {
+          "title": "Visibility",
+          "type": "string",
+          "icon": "AzureDevops",
+          "description": "Indicates whether the project is private or public"
+        },
+        "defaultTeam": {
+          "title": "Default Team",
+          "type": "string",
+          "icon": "Team",
+          "description": "Default Team of the project"
+        },
+        "link": {
+          "title": "Link",
+          "type": "string",
+          "format": "url",
+          "icon": "AzureDevops",
+          "description": "Link to azure devops project"
+        }
+      },
+      "required": []
+    },
+    "mirrorProperties": {},
+    "calculationProperties": {},
+    "aggregationProperties": {},
+    "relations": {}
+  }
+```
+
+</details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-project/_azuredevops_exporter_example_project_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-project/_azuredevops_exporter_example_project_port_app_config.mdx
@@ -1,0 +1,26 @@
+<details>
+
+<summary> Ocean integration configuration </summary>
+
+```yaml showLineNumbers
+resources:
+  - kind: project
+    selector:
+      query: 'true'
+      defaultTeam: "false"
+    port:
+      entity:
+        mappings:
+          identifier: '.id'
+          blueprint: '"project"'
+          title: .name
+          properties:
+            state: '.state'
+            revision: '.revision'
+            visibility": '.visibility'
+            defaultTeam: '.defaultTeam.name'
+            link: '.url | gsub("_apis/projects/"; "")'
+
+```
+
+</details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md
@@ -43,7 +43,7 @@ After creating the blueprints and saving the integration configuration, you will
 
 ## Mapping projects
 
-In the following example you will ingest your Azure Devops projects and their default team (Optional), you may use the following Port blueprint definitions and integration configuration:
+In the following example you will ingest your Azure Devops projects and their default team (Optional) to Port, you may use the following Port blueprint definitions and integration configuration:
 
 <ProjectBlueprint/>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md
@@ -14,6 +14,9 @@ import TeamsBlueprint from './example-teams/\_azuredevops_exporter_example_team_
 import MembersBlueprint from './example-teams/\_azuredevops_exporter_example_member_blueprint.mdx'
 import PortTeamsAppConfig from './example-teams/\_azuredevops_exporter_example_teams_port_app_config.mdx'
 
+import PortProjectAppConfig from './example-project/\_azuredevops_exporter_example_project_port_app_config.mdx'
+import ProjectBlueprint from './example-project/\_azuredevops_exporter_example_project_blueprint.mdx'
+
 # Examples
 
 ## Mapping repositories, file contents, repository policies and pull requests
@@ -37,6 +40,22 @@ In the following example you will ingest your Azure Devops repositories, their R
 :::
 
 After creating the blueprints and saving the integration configuration, you will see new entities in Port matching your repositories alongside their `README.md` file contents and pull requests.
+
+## Mapping projects
+
+In the following example you will ingest your Azure Devops projects to Port, you may use the following Port blueprint definitions and integration configuration:
+
+<ProjectBlueprint/>
+
+<PortProjectAppConfig/>
+
+:::tip To Learn more
+
+- Click [Here](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-7.2&tabs=HTTP#teamprojectreference) for the Azure Devops project object structure.
+
+- Click [Here](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/projects/get?view=azure-devops-rest-7.2#teamproject) for the Azure Devops project object structure when `defaultTeam` is set to true.
+
+:::
 
 ## Mapping pipelines
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md
@@ -43,7 +43,7 @@ After creating the blueprints and saving the integration configuration, you will
 
 ## Mapping projects
 
-In the following example you will ingest your Azure Devops projects to Port, you may use the following Port blueprint definitions and integration configuration:
+In the following example you will ingest your Azure Devops projects and their default team (Optional), you may use the following Port blueprint definitions and integration configuration:
 
 <ProjectBlueprint/>
 
@@ -52,7 +52,6 @@ In the following example you will ingest your Azure Devops projects to Port, you
 :::tip To Learn more
 
 - Click [Here](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-7.2&tabs=HTTP#teamprojectreference) for the Azure Devops project object structure.
-
 - Click [Here](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/projects/get?view=azure-devops-rest-7.2#teamproject) for the Azure Devops project object structure when `defaultTeam` is set to true.
 
 :::


### PR DESCRIPTION
# Description

Added blueprint and mapping configs examples as to docs.

## Updated docs pages

Path for the updated docs

- Blueprint (`platform-overview/port-components/blueprint](http://localhost:4000/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples#mapping-projects`)