### PR TITLE
PORT-7713 | Some configuration mappings in the docs do not have the "resources:" text

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
@@ -594,52 +594,55 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
-- kind: newRelicService
-  selector:
-    query: "true"
-    newRelicTypes: ["SERVICE", "APPLICATION"]
-    calculateOpenIssueCount: true
-    entityQueryFilter: "type in ('SERVICE','APPLICATION')"
-    entityExtraPropertiesQuery: |
-      ... on ApmApplicationEntityOutline {
-        guid
-        name
-        alertSeverity
-        applicationId
-        apmBrowserSummary {
-          ajaxRequestThroughput
-          ajaxResponseTimeAverage
-          jsErrorRate
-          pageLoadThroughput
-          pageLoadTimeAverage
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: newRelicService
+    selector:
+      query: "true"
+      newRelicTypes: ["SERVICE", "APPLICATION"]
+      calculateOpenIssueCount: true
+      entityQueryFilter: "type in ('SERVICE','APPLICATION')"
+      entityExtraPropertiesQuery: |
+        ... on ApmApplicationEntityOutline {
+          guid
+          name
+          alertSeverity
+          applicationId
+          apmBrowserSummary {
+            ajaxRequestThroughput
+            ajaxResponseTimeAverage
+            jsErrorRate
+            pageLoadThroughput
+            pageLoadTimeAverage
+          }
+          apmSummary {
+            apdexScore
+            errorRate
+            hostCount
+            instanceCount
+            nonWebResponseTimeAverage
+            nonWebThroughput
+            responseTimeAverage
+            throughput
+            webResponseTimeAverage
+            webThroughput
+          }
         }
-        apmSummary {
-          apdexScore
-          errorRate
-          hostCount
-          instanceCount
-          nonWebResponseTimeAverage
-          nonWebThroughput
-          responseTimeAverage
-          throughput
-          webResponseTimeAverage
-          webThroughput
-        }
-      }
-  port:
-    entity:
-      mappings:
-        blueprint: '"newRelicService"'
-        identifier: .guid
-        title: .name
-        properties:
-          has_apm: 'if .domain | contains("APM") then "true" else "false" end'
-          link: .permalink
-          open_issues_count: .__open_issues_count
-          reporting: .reporting
-          tags: .tags
-          domain: .domain
-          type: .type
+    port:
+      entity:
+        mappings:
+          blueprint: '"newRelicService"'
+          identifier: .guid
+          title: .name
+          properties:
+            has_apm: 'if .domain | contains("APM") then "true" else "false" end'
+            link: .permalink
+            open_issues_count: .__open_issues_count
+            reporting: .reporting
+            tags: .tags
+            domain: .domain
+            type: .type
 ```
 
 </details>
@@ -720,25 +723,28 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
-- kind: newRelicAlert
-  selector:
-    query: "true"
-    newRelicTypes: ["ISSUE"]
-  port:
-    entity:
-      mappings:
-        blueprint: '"newRelicAlert"'
-        identifier: .issueId
-        title: .title[0]
-        properties:
-          priority: .priority
-          state: .state
-          sources: .sources
-          conditionName: .conditionName
-          alertPolicyNames: .policyName
-          activatedAt: .activatedAt
-        relations:
-          newRelicService: .__APPLICATION.entity_guids + .__SERVICE.entity_guids
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: newRelicAlert
+    selector:
+      query: "true"
+      newRelicTypes: ["ISSUE"]
+    port:
+      entity:
+        mappings:
+          blueprint: '"newRelicAlert"'
+          identifier: .issueId
+          title: .title[0]
+          properties:
+            priority: .priority
+            state: .state
+            sources: .sources
+            conditionName: .conditionName
+            alertPolicyNames: .policyName
+            activatedAt: .activatedAt
+          relations:
+            newRelicService: .__APPLICATION.entity_guids + .__SERVICE.entity_guids
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/sentry.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/sentry.md
@@ -474,6 +474,8 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: project
     selector:
@@ -552,21 +554,24 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
-- kind: issue
-    selector:
-      query: "true"
-    port:
-      entity:
-        mappings:
-          identifier: ".id"
-          title: ".title"
-          blueprint: '"sentryIssue"'
-          properties:
-            link: ".permalink"
-            status: ".status"
-            isUnhandled: ".isUnhandled"
-          relations:
-            project: ".project.slug"
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: issue
+      selector:
+        query: "true"
+      port:
+        entity:
+          mappings:
+            identifier: ".id"
+            title: ".title"
+            blueprint: '"sentryIssue"'
+            properties:
+              link: ".permalink"
+              status: ".status"
+              isUnhandled: ".isUnhandled"
+            relations:
+              project: ".project.slug"
 ```
 
 </details>
@@ -626,21 +631,24 @@ The`selector.tag` key in the `project-tag` kind defines which Sentry tag data is
 :::
 
 ```yaml showLineNumbers
-- kind: project-tag
-  selector:
-    query: "true"
-    tag: "environment"
-  port:
-    entity:
-      mappings:
-        identifier: .slug + "-" + .__tags.name
-        title: .name + "-" + .__tags.name
-        blueprint: '"sentryProject"'
-        properties:
-          dateCreated: .dateCreated
-          platform: .platform
-          status: .status
-          link: .organization.links.organizationUrl + "/projects/" + .name
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: project-tag
+    selector:
+      query: "true"
+      tag: "environment"
+    port:
+      entity:
+        mappings:
+          identifier: .slug + "-" + .__tags.name
+          title: .name + "-" + .__tags.name
+          blueprint: '"sentryProject"'
+          properties:
+            dateCreated: .dateCreated
+            platform: .platform
+            status: .status
+            link: .organization.links.organizationUrl + "/projects/" + .name
 
   - kind: issue-tag
     selector:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-cost/kubecost.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-cost/kubecost.md
@@ -410,7 +410,9 @@ You will be able to see `cloud` cost data after you have successfully configured
 
 - The `port`, `entity` and the `mappings` keys are used to map the Kubecost object fields to Port entities. To create multiple mappings of the same kind, you can add another item in the `resources` array;
 
-  ```yaml showLineNumbers
+```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
   resources:
     - kind: kubesystem
       selector:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-cost/opencost.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-cost/opencost.md
@@ -391,7 +391,7 @@ The following resources can be used to map data from OpenCost, it is possible to
 
 - The `port`, `entity` and the `mappings` keys are used to map the OpenCost object fields to Port entities. To create multiple mappings of the same kind, you can add another item in the `resources` array;
 
-  ```yaml showLineNumbers
+```yaml showLineNumbers
   resources:
     - kind: cost
       selector:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
@@ -587,18 +587,21 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
-- kind: organization
-  selector:
-    query: 'true'
-  port:
-    entity:
-      mappings:
-        identifier: .id
-        title: .name
-        blueprint: '"snykOrganization"'
-        properties:
-          slug: .slug
-          url: ("https://app.snyk.io/org/" + .slug | tostring)
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: organization
+    selector:
+      query: 'true'
+    port:
+      entity:
+        mappings:
+          identifier: .id
+          title: .name
+          blueprint: '"snykOrganization"'
+          properties:
+            slug: .slug
+            url: ("https://app.snyk.io/org/" + .slug | tostring)
 ```
 </details>
 
@@ -683,21 +686,24 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
-- kind: target
-  selector:
-    query: "true"
-  port:
-    entity:
-      mappings:
-        identifier: .attributes.displayName
-        title: .attributes.displayName
-        blueprint: '"snykTarget"'
-        properties:
-          origin: .attributes.origin
-          highOpenVulnerabilities: "[.__projects[].meta.latest_issue_counts.high] | add"
-          mediumOpenVulnerabilities: "[.__projects[].meta.latest_issue_counts.medium] | add"
-          lowOpenVulnerabilities: "[.__projects[].meta.latest_issue_counts.low] | add"
-          criticalOpenVulnerabilities: "[.__projects[].meta.latest_issue_counts.critical] | add"
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: target
+    selector:
+      query: "true"
+    port:
+      entity:
+        mappings:
+          identifier: .attributes.displayName
+          title: .attributes.displayName
+          blueprint: '"snykTarget"'
+          properties:
+            origin: .attributes.origin
+            highOpenVulnerabilities: "[.__projects[].meta.latest_issue_counts.high] | add"
+            mediumOpenVulnerabilities: "[.__projects[].meta.latest_issue_counts.medium] | add"
+            lowOpenVulnerabilities: "[.__projects[].meta.latest_issue_counts.low] | add"
+            criticalOpenVulnerabilities: "[.__projects[].meta.latest_issue_counts.critical] | add"
 ```
 
 </details>
@@ -826,30 +832,33 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
-- kind: project
-  selector:
-    query: 'true'
-  port:
-    entity:
-      mappings:
-        identifier: .id
-        title: .attributes.name
-        blueprint: '"snykProject"'
-        properties:
-          url: ("https://app.snyk.io/org/" + .relationships.organization.data.id + "/project/" + .id | tostring)
-          owner: .__owner.email
-          businessCriticality: .attributes.business_criticality
-          environment: .attributes.environment
-          lifeCycle: .attributes.lifecycle
-          highOpenVulnerabilities: .meta.latest_issue_counts.high
-          mediumOpenVulnerabilities: .meta.latest_issue_counts.medium
-          lowOpenVulnerabilities: .meta.latest_issue_counts.low
-          criticalOpenVulnerabilities: .meta.latest_issue_counts.critical
-          importedBy: .__importer.email
-          tags: .attributes.tags
-        relations:
-          snykVulnerabilities: '[.__issues[] | select(.issueType == "vuln").issueData.id]'
-          snykOrganization: .relationships.organization.data.id
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: project
+    selector:
+      query: 'true'
+    port:
+      entity:
+        mappings:
+          identifier: .id
+          title: .attributes.name
+          blueprint: '"snykProject"'
+          properties:
+            url: ("https://app.snyk.io/org/" + .relationships.organization.data.id + "/project/" + .id | tostring)
+            owner: .__owner.email
+            businessCriticality: .attributes.business_criticality
+            environment: .attributes.environment
+            lifeCycle: .attributes.lifecycle
+            highOpenVulnerabilities: .meta.latest_issue_counts.high
+            mediumOpenVulnerabilities: .meta.latest_issue_counts.medium
+            lowOpenVulnerabilities: .meta.latest_issue_counts.low
+            criticalOpenVulnerabilities: .meta.latest_issue_counts.critical
+            importedBy: .__importer.email
+            tags: .attributes.tags
+          relations:
+            snykVulnerabilities: '[.__issues[] | select(.issueType == "vuln").issueData.id]'
+            snykOrganization: .relationships.organization.data.id
 ```
 
 </details>
@@ -945,25 +954,28 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
-- kind: issue
-  selector:
-    query: '.issueType == "vuln"'
-  port:
-    entity:
-      mappings:
-        identifier: .issueData.id
-        title: .issueData.title
-        blueprint: '"snykVulnerability"'
-        properties:
-          score: .priorityScore
-          packageName: .pkgName
-          packageVersions: .pkgVersions
-          type: .issueType
-          severity: .issueData.severity
-          url: .issueData.url
-          language: .issueData.language // .issueType
-          publicationTime: .issueData.publicationTime
-          isPatched: .isPatched
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: issue
+    selector:
+      query: '.issueType == "vuln"'
+    port:
+      entity:
+        mappings:
+          identifier: .issueData.id
+          title: .issueData.title
+          blueprint: '"snykVulnerability"'
+          properties:
+            score: .priorityScore
+            packageName: .pkgName
+            packageVersions: .pkgVersions
+            type: .issueType
+            severity: .issueData.severity
+            url: .issueData.url
+            language: .issueData.language // .issueType
+            publicationTime: .issueData.publicationTime
+            isPatched: .isPatched
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz.md
@@ -458,6 +458,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: control
     selector:
@@ -652,6 +654,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: issue
     selector:
@@ -727,6 +731,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: serviceTicket
   selector:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly.md
@@ -392,6 +392,8 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: project
     selector:
@@ -498,30 +500,33 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
-- kind: flag
-  selector:
-    query: "true"
-  port:
-    entity:
-      mappings:
-        identifier: .key
-        title: .name
-        blueprint: '"launchDarklyFeatureFlag"'
-        properties:
-          kind: .kind
-          description: .description
-          creationDate: .creationDate / 1000 | strftime("%Y-%m-%dT%H:%M:%SZ")
-          includeInSnippet: .includeInSnippet
-          clientSideAvailability: .clientSideAvailability
-          temporary: .temporary
-          tags: .tags
-          maintainer: ._maintainer.email
-          deprecated: .deprecated
-          variations: .variations
-          customProperties: .customProperties
-          archived: .archived
-        relations:
-          environments: .environments
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: flag
+    selector:
+      query: "true"
+    port:
+      entity:
+        mappings:
+          identifier: .key
+          title: .name
+          blueprint: '"launchDarklyFeatureFlag"'
+          properties:
+            kind: .kind
+            description: .description
+            creationDate: .creationDate / 1000 | strftime("%Y-%m-%dT%H:%M:%SZ")
+            includeInSnippet: .includeInSnippet
+            clientSideAvailability: .clientSideAvailability
+            temporary: .temporary
+            tags: .tags
+            maintainer: ._maintainer.email
+            deprecated: .deprecated
+            variations: .variations
+            customProperties: .customProperties
+            archived: .archived
+          relations:
+            environments: .environments
 ```
 </details>
 
@@ -596,6 +601,9 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
   - kind: environment
     selector:
       query: "true"

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/firehydrant.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/firehydrant.md
@@ -447,6 +447,8 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: environment
     selector:
@@ -556,6 +558,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: service
     selector:
@@ -707,6 +711,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: incident
     selector:
@@ -853,6 +859,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: retrospective
     selector:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/opsgenie.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/opsgenie.md
@@ -518,6 +518,8 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: service
     selector:
@@ -621,6 +623,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: incident
     selector:
@@ -744,6 +748,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: alert
     selector:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/pagerduty.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/pagerduty.md
@@ -709,6 +709,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: incidents
     selector:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/servicenow.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/servicenow.md
@@ -457,6 +457,8 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: sys_user_group
     selector:
@@ -521,6 +523,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: sc_catalog
     selector:
@@ -610,6 +614,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: incident
     selector:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/jenkins/jenkins.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/jenkins/jenkins.md
@@ -404,6 +404,8 @@ Examples of blueprints and the relevant integration configurations:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: job
     selector:
@@ -500,6 +502,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: build
     selector:
@@ -562,6 +566,8 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: user
   selector:


### PR DESCRIPTION
# Description
Added `resources` key to integration configurations which do not have them

## Updated docs pages

- New Relic (`/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic`)
- Sentry (`/build-your-software-catalog/sync-data-to-catalog/apm-alerting/sentry`)
- Kubecost (`/build-your-software-catalog/sync-data-to-catalog/cloud-cost/kubecost`)
- Opencost (`/build-your-software-catalog/sync-data-to-catalog/cloud-cost/opencost`)
- Snyk (`/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk`)
- Wiz (`/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz`)
- Launchdarkly (`/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly`)
- FireHydrant (`/build-your-software-catalog/sync-data-to-catalog/incident-management/firehydrant`)
- Opsgenie (`/build-your-software-catalog/sync-data-to-catalog/incident-management/opsgenie`)
- PagerDuty (`/build-your-software-catalog/sync-data-to-catalog/incident-management/pagerduty`)
- ServiceNow (`/build-your-software-catalog/sync-data-to-catalog/incident-management/servicenow`)
- Jenkins (`/build-your-software-catalog/sync-data-to-catalog/jenkins`)
