### PR TITLE
Revert LaunchDarkly integration updated blueprints before the integra…

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly.md
@@ -483,11 +483,11 @@ resources:
     "calculationProperties": {},
     "aggregationProperties": {},
     "relations": {
-      "project": {
-        "title": "Project",
-        "target": "launchDarklyProject",
-        "required": true,
-        "many": false
+      "environments": {
+        "title": "Environments",
+        "target": "launchDarklyEnvironment",
+        "required": false,
+        "many": true
       }
     }
   }
@@ -498,29 +498,29 @@ resources:
 <summary>Integration configuration</summary>
 
 ```yaml showLineNumbers
-  - kind: flag
-    selector:
-      query: "true"
-    port:
-      entity:
-        mappings:
-          identifier: .key
-          title: .name
-          blueprint: '"launchDarklyFeatureFlag"'
-          properties:
-            kind: .kind
-            description: .description
-            creationDate: .creationDate / 1000 | strftime("%Y-%m-%dT%H:%M:%SZ")
-            clientSideAvailability: .clientSideAvailability
-            temporary: .temporary
-            tags: .tags
-            maintainer: ._maintainer.email
-            deprecated: .deprecated
-            variations: .variations
-            customProperties: .customProperties
-            archived: .archived
-          relations:
-            project: .__projectKey
+- kind: flag
+  selector:
+    query: "true"
+  port:
+    entity:
+      mappings:
+        identifier: .key
+        title: .name
+        blueprint: '"launchDarklyFeatureFlag"'
+        properties:
+          kind: .kind
+          description: .description
+          creationDate: .creationDate / 1000 | strftime("%Y-%m-%dT%H:%M:%SZ")
+          clientSideAvailability: .clientSideAvailability
+          temporary: .temporary
+          tags: .tags
+          maintainer: ._maintainer.email
+          deprecated: .deprecated
+          variations: .variations
+          customProperties: .customProperties
+          archived: .archived
+        relations:
+          environments: .environments | keys
 ```
 </details>
 
@@ -614,64 +614,6 @@ resources:
             critical: .critical
           relations:
             project: .__projectKey
-```
-
-</details>
-
-### Feature Flags In Environment
-
-<details>
-<summary>Feature Flags In Environment Blueprint</summary>
-
-```json showLineNumbers
-  {
-    "identifier": "featureFlagInEnvironment",
-    "description": "This blueprint represents a feature flag in LaunchDarkly Environment.",
-    "title": "Feature Flag In Environment",
-    "icon": "Launchdarkly",
-    "schema": {
-      "properties": {},
-      "required": []
-    },
-    "mirrorProperties": {},
-    "calculationProperties": {},
-    "aggregationProperties": {},
-    "relations": {
-      "environment": {
-        "title": "Environment",
-        "target": "launchDarklyEnvironment",
-        "required": false,
-        "many": false
-      },
-      "featureFlag": {
-        "title": "Feature Flag",
-        "target": "launchDarklyFeatureFlag",
-        "required": false,
-        "many": false
-      }
-    }
-  }
-```
-</details>
-
-<details>
-<summary>Integration configuration</summary>
-
-```yaml showLineNumbers
-  - kind: flag
-    selector:
-      query: "true"
-    port:
-      itemsToParse: .environments | keys
-      entity:
-        mappings:
-          identifier: .key + "-" + .item
-          title: .key + "-" + .item
-          blueprint: '"featureFlagInEnvironment"'
-          properties: {}
-          relations:
-            environment: .item
-            featureFlag: .key
 ```
 
 </details>


### PR DESCRIPTION
…tion supports the updated mapping

# Description

Revert the updates made to the LaunchDarkly integration BPs and mapping, as they were merged to the docs before the integration was updated to support them

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
