### PR TITLE
Port 7791 update GitHub actions for k8s slack and more

### DIFF
--- a/docs/build-your-software-catalog/custom-integration/api/ci-cd/_ci_example_action.mdx
+++ b/docs/build-your-software-catalog/custom-integration/api/ci-cd/_ci_example_action.mdx
@@ -4,17 +4,45 @@
 ```json showLineNumbers
 [
   {
-    "identifier": "deploy_image",
+    "identifier": "image_deploy_image",
     "title": "Deploy image",
-    "userInputs": {
-      "properties": {}
+    "description": "Deploy image version",
+    "trigger": {
+      "type": "self-service",
+      "operation": "DAY-2",
+      "userInputs": {
+        "properties": {}
+      },
+      "blueprintIdentifier": "image"
     },
     "invocationMethod": {
       "type": "WEBHOOK",
-      "url": "https://example.com"
+      "url": "https://example.com",
+      "body": {
+        "action": "{{ .action.identifier[(\"image_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "WEBHOOK",
+              "url": "https://example.com"
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {},
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
     },
-    "trigger": "DAY-2",
-    "description": "Deploy image version"
+    "publish": true
   }
 ]
 ```

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/rollback-argocd-deployment.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/rollback-argocd-deployment.md
@@ -232,42 +232,81 @@ Follow these steps to get started:
 
 ```json showLineNumbers
 {
-  "identifier": "rollback_deployment",
+  "identifier": "service_rollback_deployment",
   "title": "Rollback Deployment",
   "icon": "GithubActions",
-  "userInputs": {
-    "properties": {
-      "image": {
-        "icon": "DefaultProperty",
-        "title": "Image",
-        "type": "string",
-        "blueprint": "image",
-        "format": "entity"
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "userInputs": {
+      "properties": {
+        "image": {
+          "icon": "DefaultProperty",
+          "title": "Image",
+          "type": "string",
+          "blueprint": "image",
+          "format": "entity"
+        },
+        "auto_merge": {
+          "title": "Auto Merge",
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the created PR should be merged or not"
+        }
       },
-      "auto_merge": {
-        "title": "Auto Merge",
-        "type": "boolean",
-        "default": false,
-        "description": "Whether the created PR should be merged or not"
-      }
+      "required": [],
+      "order": [
+        "image",
+        "auto_merge"
+      ]
     },
-    "required": [],
-    "order": [
-      "image",
-      "auto_merge"
-    ]
+    "blueprintIdentifier": "service"
   },
   "invocationMethod": {
     "type": "GITHUB",
     "org": "<GITHUB-ORG>",
     "repo": "<GITHUB-REPO-NAME>",
     "workflow": "rollback.yaml",
-    "omitUserInputs": false,
-    "omitPayload": false,
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"image\")) then \"image\" else null end}}": "{{.inputs.\"image\" | if type == \"array\" then map(.identifier) else .identifier end}}",
+      "{{if (.inputs | has(\"auto_merge\")) then \"auto_merge\" else null end}}": "{{.inputs.\"auto_merge\"}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"service_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "org": "<GITHUB-ORG>",
+              "repo": "<GITHUB-REPO-NAME>",
+              "workflow": "rollback.yaml",
+              "omitUserInputs": false,
+              "omitPayload": false,
+              "reportWorkflowStatus": true
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {
+            "{{if (.inputs | has(\"image\")) then \"image\" else null end}}": "{{.inputs.\"image\" | if type == \"array\" then map(.identifier) else .identifier end}}",
+            "{{if (.inputs | has(\"auto_merge\")) then \"auto_merge\" else null end}}": "{{.inputs.\"auto_merge\"}}"
+          },
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
+    },
     "reportWorkflowStatus": true
   },
-  "trigger": "DAY-2",
-  "requiredApproval": false
+  "requiredApproval": false,
+  "publish": true
 }
 ```
 

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/kubernetes/manage-clusters.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/kubernetes/manage-clusters.md
@@ -3,6 +3,7 @@ sidebar_position: 3
 ---
 
 import PortTooltip from "/src/components/tooltip/tooltip.jsx";
+import GithubActionModificationHint from '../../\_github_action_modification_required_hint.mdx'
 
 # Create and manage Kubernetes clusters
 
@@ -403,87 +404,127 @@ jobs:
 </details>
 
 <br /> 
-- On the [self-service](https://app.getport.io/self-serve) page, create Port actions to trigger GitHub actions for creating and deleting clusters.
+- Create the Port actions for creating and deleting clusters:
+    - Head to the [self-service](https://app.getport.io/self-serve) page.
+    - Click on the `+ New Action` button.
+    - Click on the `{...} Edit JSON` button.
+    - Copy and paste each of the following JSON configuration into the editor:
+
 
 <details>
+<GithubActionModificationHint />
 
 <summary>Create Cluster Action</summary>
 
 ```json showLineNumbers title="cluster-create-action.json"
 {
-  "identifier": "create-cluster",
+  "identifier": "cluster_create-cluster",
   "title": "Create a cluster",
-  "userInputs": {
-    "properties": {
-      "name": {
-        "type": "string",
-        "title": "Name",
-        "description": "The name of the cluster"
+  "description": "Create a new cluster.",
+  "trigger": {
+    "type": "self-service",
+    "operation": "CREATE",
+    "userInputs": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the cluster"
+        },
+        "provider": {
+          "type": "string",
+          "title": "Provider",
+          "default": "aws",
+          "description": "The provider where the cluster is hosted",
+          "enum": [
+            "aws",
+            "azure"
+          ]
+        },
+        "node-size": {
+          "type": "string",
+          "title": "Node Size",
+          "default": "small",
+          "description": "The size of the nodes",
+          "enum": [
+            "small",
+            "medium",
+            "large"
+          ]
+        },
+        "min-node-count": {
+          "type": "string",
+          "title": "Minimum number of nodes",
+          "default": "1",
+          "description": "The minimun number of nodes (autoscaler might increase this number)"
+        }
       },
-      "provider": {
-        "type": "string",
-        "title": "Provider",
-        "default": "aws",
-        "description": "The provider where the cluster is hosted",
-        "enum": ["aws", "azure"]
-      },
-      "node-size": {
-        "type": "string",
-        "title": "Node Size",
-        "default": "small",
-        "description": "The size of the nodes",
-        "enum": ["small", "medium", "large"]
-      },
-      "min-node-count": {
-        "type": "string",
-        "title": "Minimum number of nodes",
-        "default": "1",
-        "description": "The minimun number of nodes (autoscaler might increase this number)"
-      }
+      "required": [
+        "name",
+        "provider",
+        "node-size",
+        "min-node-count"
+      ]
     },
-    "required": ["name", "provider", "node-size", "min-node-count"]
+    "blueprintIdentifier": "cluster"
   },
   "invocationMethod": {
     "type": "GITHUB",
     "org": "<GITHUB_ORG_ID>",
     "repo": "<GITHUB_REPO_ID>",
     "workflow": "create-cluster.yaml",
-    "omitPayload": true
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"name\")) then \"name\" else null end}}": "{{.inputs.\"name\"}}",
+      "{{if (.inputs | has(\"provider\")) then \"provider\" else null end}}": "{{.inputs.\"provider\"}}",
+      "{{if (.inputs | has(\"node-size\")) then \"node-size\" else null end}}": "{{.inputs.\"node-size\"}}",
+      "{{if (.inputs | has(\"min-node-count\")) then \"min-node-count\" else null end}}": "{{.inputs.\"min-node-count\"}}"
+    }
   },
-  "trigger": "CREATE",
-  "description": "Create a new cluster."
+  "publish": true
 }
 ```
 
 </details>
 
 <details>
+<GithubActionModificationHint />
 
 <summary>Delete Cluster Action</summary>
 
 ```json showLineNumbers title="cluster-delete-action.json"
 {
-  "identifier": "delete-cluster",
+  "identifier": "cluster_delete-cluster",
   "title": "Delete the cluster",
-  "userInputs": {
-    "properties": {
-      "name": {
-        "type": "string",
-        "title": "Name",
-        "description": "Confirm by typing the name of the cluster"
-      }
+  "description": "Delete the cluster.",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DELETE",
+    "userInputs": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Confirm by typing the name of the cluster"
+        }
+      },
+      "required": [
+        "name"
+      ]
     },
-    "required": ["name"]
+    "blueprintIdentifier": "cluster"
   },
   "invocationMethod": {
     "type": "GITHUB",
     "org": "<GITHUB_ORG_ID>",
     "repo": "<GITHUB_REPO_ID>",
     "workflow": "delete-cluster.yaml",
-    "omitPayload": true
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"name\")) then \"name\" else null end}}": "{{.inputs.\"name\"}}"
+    }
   },
-  "trigger": "DELETE",
-  "description": "Delete the cluster."
+  "publish": true
 }
 ```
 

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/lock-and-unlock-service-in-port.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/lock-and-unlock-service-in-port.md
@@ -165,52 +165,91 @@ Follow these steps to get started:
 
 ```json showLineNumbers
 {
-  "identifier": "lock_service",
+  "identifier": "service_lock_service",
   "title": "Lock Service",
   "icon": "Lock",
-  "userInputs": {
-    "properties": {
-      "reason": {
-        "title": "Reason",
-        "type": "string"
-      },
-      "environment": {
-        "icon": "DefaultProperty",
-        "title": "Environment",
-        "type": "string",
-        "enum": [
-          "Production",
-          "Development",
-          "Staging"
-        ],
-        "enumColors": {
-          "Production": "lightGray",
-          "Development": "lightGray",
-          "Staging": "lightGray"
+  "description": "Lock service in Port",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "userInputs": {
+      "properties": {
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "environment": {
+          "icon": "DefaultProperty",
+          "title": "Environment",
+          "type": "string",
+          "enum": [
+            "Production",
+            "Development",
+            "Staging"
+          ],
+          "enumColors": {
+            "Production": "lightGray",
+            "Development": "lightGray",
+            "Staging": "lightGray"
+          }
         }
-      }
+      },
+      "required": [
+        "environment",
+        "reason"
+      ],
+      "order": [
+        "environment",
+        "reason"
+      ]
     },
-    "required": [
-      "environment",
-      "reason"
-    ],
-    "order": [
-      "environment",
-      "reason"
-    ]
+    "blueprintIdentifier": "service"
   },
   "invocationMethod": {
     "type": "GITHUB",
     "org": "<GITHUB-ORG>",
     "repo": "<GITHUB-REPO-NAME>",
     "workflow": "lock-service.yml",
-    "omitUserInputs": false,
-    "omitPayload": false,
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"reason\")) then \"reason\" else null end}}": "{{.inputs.\"reason\"}}",
+      "{{if (.inputs | has(\"environment\")) then \"environment\" else null end}}": "{{.inputs.\"environment\"}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"service_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "org": "<GITHUB-ORG>",
+              "repo": "<GITHUB-REPO-NAME>",
+              "workflow": "lock-service.yml",
+              "omitUserInputs": false,
+              "omitPayload": false,
+              "reportWorkflowStatus": true
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {
+            "{{if (.inputs | has(\"reason\")) then \"reason\" else null end}}": "{{.inputs.\"reason\"}}",
+            "{{if (.inputs | has(\"environment\")) then \"environment\" else null end}}": "{{.inputs.\"environment\"}}"
+          },
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
+    },
     "reportWorkflowStatus": true
   },
-  "trigger": "DAY-2",
-  "description": "Lock service in Port",
-  "requiredApproval": false
+  "requiredApproval": false,
+  "publish": true
 }
 ```
 
@@ -227,52 +266,91 @@ Follow these steps to get started:
 
 ```json showLineNumbers
 {
-  "identifier": "unlock_service",
+  "identifier": "service_unlock_service",
   "title": "Unlock Service",
   "icon": "Unlock",
-  "userInputs": {
-    "properties": {
-      "reason": {
-        "title": "Reason",
-        "type": "string"
-      },
-      "environment": {
-        "icon": "DefaultProperty",
-        "title": "Environment",
-        "type": "string",
-        "enum": [
-          "Production",
-          "Development",
-          "Staging"
-        ],
-        "enumColors": {
-          "Production": "lightGray",
-          "Development": "lightGray",
-          "Staging": "lightGray"
+  "description": "Unlock service in Port",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "userInputs": {
+      "properties": {
+        "reason": {
+          "title": "Reason",
+          "type": "string"
+        },
+        "environment": {
+          "icon": "DefaultProperty",
+          "title": "Environment",
+          "type": "string",
+          "enum": [
+            "Production",
+            "Development",
+            "Staging"
+          ],
+          "enumColors": {
+            "Production": "lightGray",
+            "Development": "lightGray",
+            "Staging": "lightGray"
+          }
         }
-      }
+      },
+      "required": [
+        "environment",
+        "reason"
+      ],
+      "order": [
+        "environment",
+        "reason"
+      ]
     },
-    "required": [
-      "environment",
-      "reason"
-    ],
-    "order": [
-      "environment",
-      "reason"
-    ]
+    "blueprintIdentifier": "service"
   },
   "invocationMethod": {
     "type": "GITHUB",
     "org": "<GITHUB-ORG>",
     "repo": "<GITHUB-REPO-NAME>",
     "workflow": "unlock-service.yml",
-    "omitUserInputs": false,
-    "omitPayload": false,
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"reason\")) then \"reason\" else null end}}": "{{.inputs.\"reason\"}}",
+      "{{if (.inputs | has(\"environment\")) then \"environment\" else null end}}": "{{.inputs.\"environment\"}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"service_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "org": "<GITHUB-ORG>",
+              "repo": "<GITHUB-REPO-NAME>",
+              "workflow": "unlock-service.yml",
+              "omitUserInputs": false,
+              "omitPayload": false,
+              "reportWorkflowStatus": true
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {
+            "{{if (.inputs | has(\"reason\")) then \"reason\" else null end}}": "{{.inputs.\"reason\"}}",
+            "{{if (.inputs | has(\"environment\")) then \"environment\" else null end}}": "{{.inputs.\"environment\"}}"
+          },
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
+    },
     "reportWorkflowStatus": true
   },
-  "trigger": "DAY-2",
-  "description": "Unlock service in Port",
-  "requiredApproval": false
+  "requiredApproval": false,
+  "publish": true
 }
 ```
 

--- a/docs/guides-and-tutorials/iam-permissions-guide.md
+++ b/docs/guides-and-tutorials/iam-permissions-guide.md
@@ -441,56 +441,92 @@ Let's create the Port actions to tirgger the workflows we just created:
 
     ***Replace the `<YOUR_GITHUB_ORG>` placeholder with your GitHub organization.***
 
-    ```json showLineNumbers
-    {
-        "identifier": "request_permissions",
-        "title": "Request permissions",
-        "icon": "Unlock",
-        "userInputs": {
-            "properties": {
-                "permissions": {
-                    "title": "Permissions",
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "format": "entity",
-                        "blueprint": "iam_permissions",
-                        "dataset": {
-                            "combinator": "and",
-                            "rules": [
-                                {
-                                    "property": "resource_type",
-                                    "operator": "=",
-                                    "value": {
-                                    "jqQuery": ".entity.properties.resource_type"
-                                    }
-                                }
-                            ]
-                        }
-                    }
+```json showLineNumbers
+{
+  "identifier": "aws_resource_request_permissions",
+  "title": "Request permissions",
+  "icon": "Unlock",
+  "description": "Request permissions for an AWS resource",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "userInputs": {
+      "properties": {
+        "permissions": {
+          "title": "Permissions",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "entity",
+            "blueprint": "iam_permissions",
+            "dataset": {
+              "combinator": "and",
+              "rules": [
+                {
+                  "property": "resource_type",
+                  "operator": "=",
+                  "value": {
+                    "jqQuery": ".entity.properties.resource_type"
+                  }
                 }
+              ]
+            }
+          }
+        }
+      },
+      "required": [
+        "permissions"
+      ],
+      "order": [
+        "permissions"
+      ]
+    },
+    "blueprintIdentifier": "aws_resource"
+  },
+  "invocationMethod": {
+    "type": "GITHUB",
+    "org": "<YOUR_GITHUB_ORG>",
+    "repo": "port-iam-permissions",
+    "workflow": "create-iam-permissions.yaml",
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"aws_resource_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "org": "<YOUR_GITHUB_ORG>",
+              "repo": "port-iam-permissions",
+              "workflow": "create-iam-permissions.yaml",
+              "omitUserInputs": true,
+              "omitPayload": false,
+              "reportWorkflowStatus": true
             },
-            "required": [
-                "permissions"
-            ],
-            "order": [
-                "permissions"
-            ]
-        },
-        "invocationMethod": {
-            "type": "GITHUB",
-            "org": "<YOUR_GITHUB_ORG>",
-            "repo": "port-iam-permissions",
-            "workflow": "create-iam-permissions.yaml",
-            "omitUserInputs": true,
-            "omitPayload": false,
-            "reportWorkflowStatus": true
-        },
-        "trigger": "DAY-2",
-        "description": "Request permissions for an AWS resource",
-        "requiredApproval": false
-    }
-    ```
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {
+            "{{if (.inputs | has(\"permissions\")) then \"permissions\" else null end}}": "{{.inputs.\"permissions\" | if type == \"array\" then map(.identifier) else .identifier end}}"
+          },
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
+    },
+    "reportWorkflowStatus": true
+  },
+  "requiredApproval": false,
+  "publish": true
+}
+```
 </details>
 
 <details>
@@ -500,29 +536,63 @@ Let's create the Port actions to tirgger the workflows we just created:
 
     ***Replace the `<YOUR_GITHUB_ORG>` placeholder with your GitHub organization.***
 
-    ```json showLineNumbers
-    {
-        "identifier": "revoke_permissions",
-        "title": "Revoke permissions",
-        "icon": "Alert",
-        "userInputs": {
-            "properties": {},
-            "required": []
+```json showLineNumbers
+{
+  "identifier": "provisioned_permissions_revoke_permissions",
+  "title": "Revoke permissions",
+  "icon": "Alert",
+  "description": "Revokes IAM permissions",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DELETE",
+    "userInputs": {
+      "properties": {},
+      "required": []
+    },
+    "blueprintIdentifier": "provisioned_permissions"
+  },
+  "invocationMethod": {
+    "type": "GITHUB",
+    "org": "<YOUR_GITHUB_ORG>",
+    "repo": "port-iam-permissions",
+    "workflow": "delete-iam-permissions.yaml",
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"provisioned_permissions_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
         },
-        "invocationMethod": {
-            "type": "GITHUB",
-            "org": "<YOUR_GITHUB_ORG>",
-            "repo": "port-iam-permissions",
-            "workflow": "delete-iam-permissions.yaml",
-            "omitUserInputs": true,
-            "omitPayload": false,
-            "reportWorkflowStatus": true
-        },
-        "trigger": "DELETE",
-        "description": "Revokes IAM permissions",
-        "requiredApproval": false
-    }
-    ```
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "org": "<YOUR_GITHUB_ORG>",
+              "repo": "port-iam-permissions",
+              "workflow": "delete-iam-permissions.yaml",
+              "omitUserInputs": true,
+              "omitPayload": false,
+              "reportWorkflowStatus": true
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {},
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
+    },
+    "reportWorkflowStatus": true
+  },
+  "requiredApproval": false,
+  "publish": true
+}
+```
 </details>
 
 ## Manage permissions using Port


### PR DESCRIPTION
# Description

Update these actions to use the new actions structure

## Updated docs pages

docs/create-self-service-experiences/setup-backend/github-workflow/examples/kubernetes/manage-clusters.md
docs/create-self-service-experiences/setup-backend/github-workflow/examples/promote-to-production.md
docs/create-self-service-experiences/setup-backend/github-workflow/examples/broadcast-api-consumers-message.md
docs/create-self-service-experiences/setup-backend/github-workflow/examples/manage-pull-requests.md
docs/create-self-service-experiences/setup-backend/github-workflow/examples/nudge-pr-reviewers.md
docs/create-self-service-experiences/setup-backend/github-workflow/examples/open-slack-channel.md

docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/rollback-argocd-deployment.md
docs/create-self-service-experiences/setup-backend/github-workflow/examples/lock-and-unlock-service-in-port.md

docs/guides-and-tutorials/iam-permissions-guide.md
docs/build-your-software-catalog/custom-integration/api/ci-cd/_ci_example_action.mdx