### PR TITLE
PORT-7790 | Update GitHub actions for SonarQube, Jira and Datadog

### DIFF
--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/Datadog/trigger-datadog-incident.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/Datadog/trigger-datadog-incident.md
@@ -265,9 +265,13 @@ Make sure to replace `<GITHUB_ORG>` and `<GITHUB_REPO>` with your GitHub organiz
 
 ```json showLineNumbers
 {
-    "identifier": "trigger_datadog_incident",
-    "title": "Trigger Datadog Incident",
-    "icon": "Datadog",
+  "identifier": "datadogIncident_trigger_datadog_incident",
+  "title": "Trigger Datadog Incident",
+  "icon": "Datadog",
+  "description": "Triggers Datadog incident",
+  "trigger": {
+    "type": "self-service",
+    "operation": "CREATE",
     "userInputs": {
       "properties": {
         "customerImpactScope": {
@@ -309,18 +313,59 @@ Make sure to replace `<GITHUB_ORG>` and `<GITHUB_REPO>` with your GitHub organiz
         "notificationHandleEmail"
       ]
     },
-    "invocationMethod": {
-      "type": "GITHUB",
-      "org": "<GITHUB_ORG>",
-      "repo": "<GITHUB_REPO>",
-      "workflow": "trigger-datadog-incident.yml",
-      "omitUserInputs": false,
-      "omitPayload": false,
-      "reportWorkflowStatus": true
+    "blueprintIdentifier": "datadogIncident"
+  },
+  "invocationMethod": {
+    "type": "GITHUB",
+    "org": "<Enter GitHub organization>",
+    "repo": "<Enter GitHub repository>",
+    "workflow": "trigger-datadog-incident.yml",
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"customerImpactScope\")) then \"customerImpactScope\" else null end}}": "{{.inputs.\"customerImpactScope\"}}",
+      "{{if (.inputs | has(\"customerImpacted\")) then \"customerImpacted\" else null end}}": "{{.inputs.\"customerImpacted\"}}",
+      "{{if (.inputs | has(\"title\")) then \"title\" else null end}}": "{{.inputs.\"title\"}}",
+      "{{if (.inputs | has(\"notificationHandleName\")) then \"notificationHandleName\" else null end}}": "{{.inputs.\"notificationHandleName\"}}",
+      "{{if (.inputs | has(\"notificationHandleEmail\")) then \"notificationHandleEmail\" else null end}}": "{{.inputs.\"notificationHandleEmail\"}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"datadogIncident_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "repo": "<Enter GitHub repository>",
+              "org": "<Enter GitHub organization>",
+              "workflow": "trigger-datadog-incident.yml",
+              "omitUserInputs": false,
+              "omitPayload": false,
+              "reportWorkflowStatus": true
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {
+            "{{if (.inputs | has(\"customerImpactScope\")) then \"customerImpactScope\" else null end}}": "{{.inputs.\"customerImpactScope\"}}",
+            "{{if (.inputs | has(\"customerImpacted\")) then \"customerImpacted\" else null end}}": "{{.inputs.\"customerImpacted\"}}",
+            "{{if (.inputs | has(\"title\")) then \"title\" else null end}}": "{{.inputs.\"title\"}}",
+            "{{if (.inputs | has(\"notificationHandleName\")) then \"notificationHandleName\" else null end}}": "{{.inputs.\"notificationHandleName\"}}",
+            "{{if (.inputs | has(\"notificationHandleEmail\")) then \"notificationHandleEmail\" else null end}}": "{{.inputs.\"notificationHandleEmail\"}}"
+          },
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
     },
-    "trigger": "CREATE",
-    "description": "Triggers Datadog incident",
-    "requiredApproval": false
+    "reportWorkflowStatus": true
+  },
+  "requiredApproval": false,
+  "publish": true
 }
 ```
 </details>

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/Jira/change-status-and-assignee-of-jira-ticket.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/Jira/change-status-and-assignee-of-jira-ticket.md
@@ -322,59 +322,98 @@ jobs:
 
 ```json showLineNumbers
 {
-  "identifier": "change_jira_ticket_status",
+  "identifier": "jiraIssue_change_jira_ticket_status",
   "title": "Change Jira ticket status and assignee",
   "icon": "Jira",
-  "userInputs": {
-    "properties": {
-      "status": {
-        "icon": "DefaultProperty",
-        "title": "Status",
-        "type": "string",
-        "enum": [
-          "To Do",
-          "In Progress",
-          "Code Review",
-          "Product Review",
-          "Waiting For Prod",
-          "Done"
-        ],
-        "enumColors": {
-          "To Do": "lightGray",
-          "In Progress": "bronze",
-          "Code Review": "darkGray",
-          "Product Review": "purple",
-          "Waiting For Prod": "orange",
-          "Done": "green"
+  "description": "Transition a ticket to another status.",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "userInputs": {
+      "properties": {
+        "status": {
+          "icon": "DefaultProperty",
+          "title": "Status",
+          "type": "string",
+          "enum": [
+            "To Do",
+            "In Progress",
+            "Code Review",
+            "Product Review",
+            "Waiting For Prod",
+            "Done"
+          ],
+          "enumColors": {
+            "To Do": "lightGray",
+            "In Progress": "bronze",
+            "Code Review": "darkGray",
+            "Product Review": "purple",
+            "Waiting For Prod": "orange",
+            "Done": "green"
+          }
+        },
+        "assignee": {
+          "type": "string",
+          "title": "Assignee",
+          "icon": "User",
+          "format": "user"
         }
       },
-      "assignee": {
-        "type": "string",
-        "title": "Assignee",
-        "description": "Name of the user or email",
-        "icon": "Jira"
-      }
+      "required": [
+        "status",
+        "assignee"
+      ],
+      "order": [
+        "status"
+      ]
     },
-    "required": [
-      "status"
-    ],
-    "order": [
-      "status",
-      "assignee"
-    ]
+    "blueprintIdentifier": "jiraIssue"
   },
   "invocationMethod": {
     "type": "GITHUB",
-    "repo": "<GITHUB_REPO>",
-    "org": "<GITHUB_ORG>",
-    "workflow": "change-jira-ticket-status-and-assignee.yml",
-    "omitUserInputs": false,
-    "omitPayload": false,
+    "org": "<Enter GitHub organization>",
+    "repo": "<Enter GitHub repository>",
+    "workflow": "change_jira_ticket_status_and_assignee.yml",
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"status\")) then \"status\" else null end}}": "{{.inputs.\"status\"}}",
+      "{{if (.inputs | has(\"assignee\")) then \"assignee\" else null end}}": "{{.inputs.\"assignee\"}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"jiraIssue_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "org": "<Enter GitHub organization>",
+              "repo": "<Enter GitHub repository>",
+              "workflow": "change_jira_ticket_status_and_assignee.yml",
+              "omitUserInputs": false,
+              "omitPayload": false,
+              "reportWorkflowStatus": true
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {
+            "{{if (.inputs | has(\"status\")) then \"status\" else null end}}": "{{.inputs.\"status\"}}",
+            "{{if (.inputs | has(\"assignee\")) then \"assignee\" else null end}}": "{{.inputs.\"assignee\"}}"
+          },
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
+    },
     "reportWorkflowStatus": true
   },
-  "trigger": "DAY-2",
-  "description": "Transition a ticket to another status.",
-  "requiredApproval": false
+  "requiredApproval": false,
+  "publish": true
 }
 ```
 

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/Jira/open-jira-issue-with-automatic-label.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/Jira/open-jira-issue-with-automatic-label.md
@@ -311,58 +311,108 @@ Make sure to replace `<GITHUB_ORG>` and `<GITHUB_REPO>` with your GitHub organiz
 
 ```json showLineNumbers
 {
-  "identifier": "open_jira_issue_with_automatic_label",
-  "title": "Open Jira issue with automatic label",
+  "identifier": "jiraIssue_open_jira_issue_with_automatic_label",
+  "title": "Open Jira Issue with automatic label",
   "icon": "Jira",
-  "userInputs": {
-    "properties": {
-      "title": {
-        "title": "Title",
-        "description": "Title of the Jira issue",
-        "icon": "Jira",
-        "type": "string"
-      },
-      "type": {
-        "title": "Type",
-        "description": "Issue type",
-        "icon": "Jira",
-        "type": "string",
-        "default": "Task",
-        "enum": [
-          "Task",
-          "Story",
-          "Bug",
-          "Epic"
-        ],
-        "enumColors": {
-          "Task": "blue",
-          "Story": "green",
-          "Bug": "red",
-          "Epic": "pink"
+  "description": "Creates a Jira issue with a label to the concerned service.",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "userInputs": {
+      "properties": {
+        "title": {
+          "title": "Title",
+          "description": "Title of the Jira issue",
+          "icon": "Jira",
+          "type": "string"
+        },
+        "type": {
+          "title": "Type",
+          "description": "Issue type",
+          "icon": "Jira",
+          "type": "string",
+          "default": "Task",
+          "enum": [
+            "Task",
+            "Story",
+            "Bug",
+            "Epic"
+          ],
+          "enumColors": {
+            "Task": "blue",
+            "Story": "green",
+            "Bug": "red",
+            "Epic": "pink"
+          }
+        },
+        "project": {
+          "title": "Project",
+          "description": "The issue will be created on this project",
+          "icon": "Jira",
+          "type": "string",
+          "blueprint": "jiraProject",
+          "format": "entity"
         }
-      }
+      },
+      "required": [
+        "title",
+        "type",
+        "project"
+      ],
+      "order": [
+        "title",
+        "type"
+      ]
     },
-    "required": [
-      "title",
-      "type"
-    ],
-    "order": [
-      "title",
-      "type"
-    ]
+    "blueprintIdentifier": "jiraIssue"
   },
   "invocationMethod": {
     "type": "GITHUB",
-    "org": "<GITHUB_ORG>",
-    "repo": "<GITHUB_REPO>",
+    "org": "<Enter GitHub organization>",
+    "repo": "<Enter GitHub repository>",
     "workflow": "open-jira-issue-with-automatic-label.yml",
-    "omitUserInputs": false,
-    "omitPayload": false,
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"title\")) then \"title\" else null end}}": "{{.inputs.\"title\"}}",
+      "{{if (.inputs | has(\"type\")) then \"type\" else null end}}": "{{.inputs.\"type\"}}",
+      "{{if (.inputs | has(\"project\")) then \"project\" else null end}}": "{{.inputs.\"project\" | if type == \"array\" then map(.identifier) else .identifier end}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"jiraIssue_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "repo": "<Enter GitHub repository>",
+              "org": "<Enter GitHub organization>",
+              "workflow": "open-jira-issue-with-automatic-label.yml",
+              "omitUserInputs": false,
+              "omitPayload": false,
+              "reportWorkflowStatus": true
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {
+            "{{if (.inputs | has(\"title\")) then \"title\" else null end}}": "{{.inputs.\"title\"}}",
+            "{{if (.inputs | has(\"type\")) then \"type\" else null end}}": "{{.inputs.\"type\"}}",
+            "{{if (.inputs | has(\"project\")) then \"project\" else null end}}": "{{.inputs.\"project\" | if type == \"array\" then map(.identifier) else .identifier end}}"
+          },
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
+    },
     "reportWorkflowStatus": true
   },
-  "trigger": "DAY-2",
-  "description": "Creates a Jira issue with a label to the concerned service.",
-  "requiredApproval": false
+  "requiredApproval": false,
+  "publish": true
 }
 ```
 </details>

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/Jira/report-a-bug.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/Jira/report-a-bug.md
@@ -40,37 +40,81 @@ You can add this action to the `Service` or `Jira Issue` blueprints
 
 ```json showLineNumbers
 {
-  "identifier": "report_a_bug",
+  "identifier": "jiraIssue_report_a_bug",
   "title": "Report a bug",
   "icon": "Jira",
-  "userInputs": {
-    "properties": {
-      "description": {
-        "icon": "DefaultProperty",
-        "title": "Description",
-        "type": "string"
+  "description": "Report a bug in Port to our product team.",
+  "trigger": {
+    "type": "self-service",
+    "operation": "CREATE",
+    "userInputs": {
+      "properties": {
+        "description": {
+          "icon": "DefaultProperty",
+          "title": "Description",
+          "type": "string"
+        },
+        "short_title": {
+          "icon": "DefaultProperty",
+          "title": "Short title",
+          "type": "string"
+        }
       },
-      "short_title": {
-        "icon": "DefaultProperty",
-        "title": "Short title",
-        "type": "string"
-      }
-    },
-    "required": ["short_title", "description"],
-    "order": ["short_title", "description"]
+      "required": [
+        "short_title",
+        "description"
+      ],
+      "order": [
+        "short_title",
+        "description"
+      ]
+    }
   },
   "invocationMethod": {
     "type": "GITHUB",
-    "omitPayload": false,
-    "omitUserInputs": false,
-    "reportWorkflowStatus": true,
-    "repo": "<Enter GitHub repository>",
     "org": "<Enter GitHub organization>",
-    "workflow": "jira.yml"
+    "repo": "<Enter GitHub repository>",
+    "workflow": "report-a-bug.yml",
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"description\")) then \"description\" else null end}}": "{{.inputs.\"description\"}}",
+      "{{if (.inputs | has(\"short_title\")) then \"short_title\" else null end}}": "{{.inputs.\"short_title\"}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"jiraIssue_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "omitPayload": false,
+              "omitUserInputs": false,
+              "reportWorkflowStatus": true,
+              "org": "<Enter GitHub organization>",
+              "repo": "<Enter GitHub repository>",
+              "workflow": "report-a-bug.yml"
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {
+            "{{if (.inputs | has(\"description\")) then \"description\" else null end}}": "{{.inputs.\"description\"}}",
+            "{{if (.inputs | has(\"short_title\")) then \"short_title\" else null end}}": "{{.inputs.\"short_title\"}}"
+          },
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
+    },
+    "reportWorkflowStatus": true
   },
-  "trigger": "CREATE",
-  "description": "Report a bug in Port to our product team.",
-  "requiredApproval": false
+  "requiredApproval": false,
+  "publish": true
 }
 ```
 

--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/SonarQube/add-tags-to-sonarqube-project.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/SonarQube/add-tags-to-sonarqube-project.md
@@ -168,37 +168,74 @@ Make sure to replace `<GITHUB_ORG>` and `<GITHUB_REPO>` with your GitHub organiz
 
 ```json showLineNumbers
 {
-  "identifier": "add_tags_to_sonar_qube_project",
+  "identifier": "sonarQubeProject_add_tags_to_sonar_qube_project",
   "title": "Add Tags to SonarQube project",
   "icon": "sonarqube",
-  "userInputs": {
-    "properties": {
-      "tags": {
-        "title": "Tags",
-        "description": "Comma separated list of tags",
-        "icon": "DefaultProperty",
-        "type": "string"
-      }
+  "description": "Adds additional tags to a project in SonarQube",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "userInputs": {
+      "properties": {
+        "tags": {
+          "title": "Tags",
+          "description": "Comma separated list of tags",
+          "icon": "DefaultProperty",
+          "type": "string"
+        }
+      },
+      "required": [
+        "tags"
+      ],
+      "order": [
+        "tags"
+      ]
     },
-    "required": [
-      "tags"
-    ],
-    "order": [
-      "tags"
-    ]
+    "blueprintIdentifier": "sonarQubeProject"
   },
   "invocationMethod": {
     "type": "GITHUB",
-    "org": "<GITHUB_ORG>",
-    "repo": "<GITHUB_REPO>",
+    "org": "<Enter GitHub organization>",
+    "repo": "<Enter GitHub repository>",
     "workflow": "add-tags-to-sonarqube-project.yml",
-    "omitUserInputs": false,
-    "omitPayload": false,
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"tags\")) then \"tags\" else null end}}": "{{.inputs.\"tags\"}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"sonarQubeProject_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "repo": "<Enter GitHub repository>",
+              "org": "<Enter GitHub organization>",
+              "workflow": "add-tags-to-sonarqube-project.yml",
+              "omitUserInputs": false,
+              "omitPayload": false,
+              "reportWorkflowStatus": true
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {
+            "{{if (.inputs | has(\"tags\")) then \"tags\" else null end}}": "{{.inputs.\"tags\"}}"
+          },
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
+    },
     "reportWorkflowStatus": true
   },
-  "trigger": "DAY-2",
-  "description": "Adds additional tags to a project in SonarQube",
-  "requiredApproval": false
+  "requiredApproval": false,
+  "publish": true
 }
 ```
 </details>


### PR DESCRIPTION
# Description

Since the payload from Port actions are changing, this task involves updating the action blueprint and respective 
GitHub actions for Jira, Sonarqube and Datadog to match the new format


## Updated docs pages

- Trigger Datadog incident (`docs/create-self-service-experiences/setup-backend/github-workflow/examples/Datadog/trigger-datadog-incident.md`)
- Change status and assignee of Jira ticket (`docs/create-self-service-experiences/setup-backend/github-workflow/examples/Jira/change-status-and-assignee-of-jira-ticket.md`)
- Open Jira issue with automatic label (`docs/create-self-service-experiences/setup-backend/github-workflow/examples/Jira/open-jira-issue-with-automatic-label.md`)
- Report a bug (`docs/create-self-service-experiences/setup-backend/github-workflow/examples/Jira/report-a-bug.md`)
- Add tags to SonarQube project (`docs/create-self-service-experiences/setup-backend/github-workflow/examples/Jira/report-a-bug.md`)
