### PR TITLE
removed status.conditions from v1/pods example

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/kubernetes/basic-example.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/kubernetes/basic-example.md
@@ -111,10 +111,6 @@ In the following example you will export your Kubernetes `Replica Sets` and `Pod
       "containers": {
         "title": "Containers",
         "type": "array"
-      },
-      "conditions": {
-        "type": "array",
-        "title": "Conditions"
       }
     },
     "required": []
@@ -165,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               deploymentConfig: .metadata.ownerReferences[0].name
 ```


### PR DESCRIPTION
# Description

Removed .status.conditions from v1/pods kind in the k8s example
This property causes many requests for updates in pods.

## Updated docs pages

- Example k8s (`/build-your-software-catalog/sync-data-to-catalog/kubernetes/basic-example)
