### PR TITLE
PORT-7789 | Update Action Guide for Synchronizing an Argo CD Application

### DIFF
--- a/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/sync-argocd-app.md
+++ b/docs/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/sync-argocd-app.md
@@ -5,104 +5,162 @@ import Tabs from "@theme/Tabs"
 import TabItem from "@theme/TabItem"
 import PortTooltip from "/src/components/tooltip/tooltip.jsx";
 
-# Synchronize ArgoCD Application
+import GithubActionModificationHint from '../../\_github_action_modification_required_hint.mdx'
+import GithubDedicatedRepoHint from '../../\_github_dedicated_workflows_repository_hint.mdx'
 
-In the following guide, we are going to create a self-service action in Port that executes a [GitHub workflow](/create-self-service-experiences/setup-backend/github-workflow/github-workflow.md) to sync an argocd application.
+# Synchronize Argo CD Application
+
+In the following guide, we are going to create a self-service action in Port that executes a [GitHub workflow](/create-self-service-experiences/setup-backend/github-workflow/github-workflow.md) to sync an argo cd application. With this, you can manage your Argo CD Application without leaving Port.
 
 
-:::tip Prerequisites
-1. This guide assumes that you already have a blueprint for an ArgoCD Application with some resources. If you haven't done so yet, create the blueprint by referring to this [guide](/build-your-software-catalog/sync-data-to-catalog/argocd#application) first.
-2. Prior knowledge of Port Actions is essential for following this guide. Learn more about them [here](/create-self-service-experiences/setup-ui-for-action/).
-3. A GitHub repository to contain your action resources i.e. the github workflow file.
+## Prerequisites
+1. [Port's GitHub app](https://github.com/apps/getport-io) needs to be installed.
+2. In your GitHub repository, [go to **Settings > Secrets**](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) and add the following secrets:
+   - `ARGOCD_TOKEN` - Argo CD token [learn more](https://argo-cd.readthedocs.io/en/stable/developer-guide/api-docs/).
+   - `ARGOCD_APPLICATION_HOST` - The host URL of your deployed Argo CD instance. For example, my-argocd-app.com.
+   - `PORT_CLIENT_ID` - Your port `client id` [How to get the credentials](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials).
+   - `PORT_CLIENT_SECRET` - Your port `client secret` [How to get the credentials](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials).
+3. Optional - Install Port's Argo CD integration [learn more](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/argocd/)
+
+:::tip Argo CD Integration
+	This step is not required for this example, but it will create all the blueprint boilerplate for you, and also ingest and update the catalog in real time with your Argo CD Applications.
 :::
 
-## Steps
-
-
-Follow these steps to get started:
-
-1. Create the following GitHub Action secrets:
-    1. `ARGOCD_TOKEN` - Argocd token [learn more](https://argo-cd.readthedocs.io/en/stable/developer-guide/api-docs/)
-    2. `PORT_CLIENT_ID` - Port Client ID [learn more](/build-your-software-catalog/custom-integration/api/#get-api-token).
-    3. `PORT_CLIENT_SECRET` - Port Client Secret [learn more](/build-your-software-catalog/custom-integration/api/#get-api-token).
-
-2. Install Port's GitHub app by clicking [here](https://github.com/apps/getport-io/installations/new).
-
-3. Create Port action using the following JSON definition:
+4. In Case you decided not to install the Argo CD integration, you will need to create a blueprint for the Argo CD Application in Port.
 
 <details>
-<summary>Port Action: Sync ArgoCD Application </summary>
-:::note
-Replace the placeholders for GITHUB_ORG_NAME and GITHUB_REPO_NAME in your Port Action to match your GitHub environment.
-:::
+	<summary>Argo CD Application Blueprint</summary>
 
 ```json showLineNumbers
-[
-{
-  "identifier": "sync_application",
-  "title": "Sync Application",
-  "icon": "Argo",
-  "userInputs": {
-    "properties": {
-      "application_name": {
-        "title": "Application Name",
-        "description": "ArgoCD Application Name",
-        "icon": "Argo",
-        "type": "string",
-        "default": {
-          "jqQuery": ".entity.title"
+  {
+    "identifier": "argocdApplication",
+    "description": "This blueprint represents an ArgoCD Application",
+    "title": "Running Service",
+    "icon": "Argo",
+    "schema": {
+      "properties": {
+        "gitRepo": {
+          "type": "string",
+          "icon": "Git",
+          "title": "Repository URL",
+          "description": "The URL of the Git repository containing the application source code"
+        },
+        "gitPath": {
+          "type": "string",
+          "title": "Path",
+          "description": "The path within the Git repository where the application manifests are located"
+        },
+        "destinationServer": {
+          "type": "string",
+          "title": "Destination Server",
+          "description": "The URL of the target cluster's Kubernetes control plane API"
+        },
+        "revision": {
+          "type": "string",
+          "title": "Revision",
+          "description": "Revision contains information about the revision the comparison has been performed to"
+        },
+        "targetRevision": {
+          "type": "string",
+          "title": "Target Revision",
+          "description": "Target Revision defines the revision of the source to sync the application to. In case of Git, this can be commit, tag, or branch"
+        },
+        "syncStatus": {
+          "type": "string",
+          "title": "Sync Status",
+          "enum": [
+            "Synced",
+            "OutOfSync",
+            "Unknown"
+          ],
+          "enumColors": {
+            "Synced": "green",
+            "OutOfSync": "red",
+            "Unknown": "lightGray"
+          },
+          "description": "Status is the sync state of the comparison"
+        },
+        "healthStatus": {
+          "type": "string",
+          "title": "Health Status",
+          "enum": [
+            "Healthy",
+            "Missing",
+            "Suspended",
+            "Degraded",
+            "Progressing",
+            "Unknown"
+          ],
+          "enumColors": {
+            "Healthy": "green",
+            "Missing": "yellow",
+            "Suspended": "purple",
+            "Degraded": "red",
+            "Progressing": "blue",
+            "Unknown": "lightGray"
+          },
+          "description": "Status holds the status code of the application or resource"
+        },
+        "createdAt": {
+          "title": "Created At",
+          "type": "string",
+          "format": "date-time",
+          "description": "The created timestamp of the application"
+        },
+        "labels": {
+          "type": "object",
+          "title": "Labels",
+          "description": "Map of string keys and values that can be used to organize and categorize object"
+        },
+        "annotations": {
+          "type": "object",
+          "title": "Annotations",
+          "description": "Annotations are unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata"
         }
       },
-      "application_host": {
-        "icon": "Argo",
-        "title": "Application Host",
-        "description": "ArgoCD Application Host. e.g app.example.com",
-        "type": "string"
-      }
+      "required": []
     },
-    "required": [
-      "application_host",
-      "application_name"
-    ],
-    "order": [
-      "application_host",
-      "application_name"
-    ]
-  },
-  "invocationMethod": {
-    "type": "GITHUB",
-    "org": "<GITHUB_ORG_NAME>",
-    "repo": "<GITHUB_REPO_NAME>"
-    "workflow": "sync-argocd-app.yaml",
-    "omitUserInputs": false,
-    "omitPayload": false,
-    "reportWorkflowStatus": true
-  },
-  "trigger": "DAY-2",
-  "description": "Sync An ArgoCD Application",
-  "requiredApproval": false
-}  
-]
+    "mirrorProperties": {},
+    "calculationProperties": {},
+    "relations": {
+      "project": {
+        "title": "ArgoCD Project",
+        "target": "argocdProject",
+        "required": false,
+        "many": false
+      },
+      "cluster": {
+        "title": "ArgoCD Cluster",
+        "target": "argocdCluster",
+        "required": false,
+        "many": false
+      },
+      "namespace": {
+        "title": "ArgoCD Namespace",
+        "target": "argocdNamespace",
+        "required": false,
+        "many": false
+      }
+    }
+  }
 ```
 </details>
 
 4. Create a workflow file under `.github/workflows/sync-argocd-app.yaml` with the following content:
 
+<GithubDedicatedRepoHint/>
+
 <details>
  <summary>GitHub Workflow </summary>
 
 ```yml showLineNumbers
-name: Sync ArgoCD Application
+name: Sync Argo CD Application
 on:
   workflow_dispatch:
     inputs:
       application_name:
-        description: The ArgoCD Application Name. e.g. app.example.com
+        description: The Argo CD Application Name. e.g. app.example.com
         required: true
-      application_host:
-        description: The ArgoCD Application host.
-        required: true
-        type: string
       port_payload:
         required: true
         description: >-
@@ -123,10 +181,10 @@ jobs:
           runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
           logMessage: "About to make a request to argocd server..."
 
-      - name: Sync ArgoCD Application
+      - name: Sync Argo CD Application
         uses: omegion/argocd-actions@v1
         with:
-          address: ${{ github.event.inputs.application_host }}
+          address: ${{ secrets.ARGOCD_APPLICATION_HOST }}
           token: ${{ secrets.ARGOCD_TOKEN }}
           action: sync
           appName: ${{ github.event.inputs.application_name }}
@@ -140,7 +198,7 @@ jobs:
           baseUrl: https://api.getport.io
           operation: PATCH_RUN
           runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
-          logMessage: "Request to sync argocd application failed ..."
+          logMessage: "Request to sync Argo CD application failed ..."
     
     - name: Report Sync Success
         uses: port-labs/port-github-action@v1
@@ -150,8 +208,107 @@ jobs:
           baseUrl: https://api.getport.io
           operation: PATCH_RUN
           runId: ${{fromJson(github.event.inputs.port_payload).context.runId}}
-          logMessage: "Successfully synced ArgoCD Aplication ✅"
+          logMessage: "Successfully synced Argo CD Aplication ✅"
 ```
 </details>
 
-5. Trigger the action from the [Self-service](https://app.getport.io/self-serve) tab of your Port application.
+## Port Configuration
+
+Create a new self service action using the following JSON configuration.
+
+<details>
+<summary>Sync Argo CD Application (click to expand) </summary>
+<GithubActionModificationHint/>
+
+```json showLineNumbers
+{
+  "identifier": "argocdApplication_sync_application",
+  "title": "Sync Application",
+  "icon": "Argo",
+  "description": "Sync An Argo CD Application",
+  "trigger": {
+    "type": "self-service",
+    "operation": "DAY-2",
+    "userInputs": {
+      "properties": {
+        "application_name": {
+          "title": "Application Name",
+          "description": "Argo CD Application Name",
+          "icon": "Argo",
+          "type": "string",
+          "default": {
+            "jqQuery": ".entity.title"
+          }
+        }
+      },
+      "required": [
+        "application_name"
+      ],
+      "order": [
+        "application_name"
+      ]
+    },
+    "blueprintIdentifier": "argocdApplication"
+  },
+  "invocationMethod": {
+    "type": "GITHUB",
+    "org": "<GITHUB_ORG>",
+    "repo": "<GITHUB_REPO>",
+    "workflow": "sync-argocd-app.yaml",
+    "workflowInputs": {
+      "{{if (.inputs | has(\"ref\")) then \"ref\" else null end}}": "{{.inputs.\"ref\"}}",
+      "{{if (.inputs | has(\"application_name\")) then \"application_name\" else null end}}": "{{.inputs.\"application_name\"}}",
+      "port_payload": {
+        "action": "{{ .action.identifier[(\"argocdApplication_\" | length):] }}",
+        "resourceType": "run",
+        "status": "TRIGGERED",
+        "trigger": "{{ .trigger | {by, origin, at} }}",
+        "context": {
+          "entity": "{{.entity.identifier}}",
+          "blueprint": "{{.action.blueprint}}",
+          "runId": "{{.run.id}}"
+        },
+        "payload": {
+          "entity": "{{ (if .entity == {} then null else .entity end) }}",
+          "action": {
+            "invocationMethod": {
+              "type": "GITHUB",
+              "org": "<GITHUB_ORG>",
+              "repo": "<GITHUB_REPO>",
+              "workflow": "sync-argocd-app.yaml",
+              "omitUserInputs": false,
+              "omitPayload": false,
+              "reportWorkflowStatus": true
+            },
+            "trigger": "{{.trigger.operation}}"
+          },
+          "properties": {
+            "{{if (.inputs | has(\"application_name\")) then \"application_name\" else null end}}": "{{.inputs.\"application_name\"}}"
+          },
+          "censoredProperties": "{{.action.encryptedProperties}}"
+        }
+      }
+    },
+    "reportWorkflowStatus": true
+  },
+  "requiredApproval": false,
+  "publish": true
+}
+```
+</details>
+
+Now you should see the `Sync Argo CD Application` action in the self-service page. 🎉
+
+## Let's test it!
+
+1. Head to the [Self Service hub](https://app.getport.io/self-serve)
+2. Click on the `Sync Argo CD Application` action
+3. Choose the Argo CD Application you want to synchronize (In case you didn't install the [Argo CD integration](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/argocd/), it means you don't have any Argo CD application in Port yet, so you will need to create one manually in Port to test this action)
+4. Select the application you want to sync. The `application_name` field should auto-fill after this, if not, manually enter the application name.
+5. Click on `Execute`
+6. Done! wait for the application to be synchronized.
+
+Congrats 🎉 You've successfully synchronized your Argo CD Application in Port 🔥
+
+## More Self Service Argo CD Actions Examples
+- [Rollback Argo CD Deployment](/create-self-service-experiences/setup-backend/github-workflow/examples/ArgoCD/rollback-argocd-deployment) using Port's self-service actions.


### PR DESCRIPTION
# Description

Update Self Service Guides for `Sync Argo CD App` github action following the new self service actions api

## Updated docs pages

- Resource Path (`/create-self-service-experiences/setup-backend/github-workflow/examples/argocd/sync-argocd-app`)
