### PR TITLE
Remove redundant empty bullet

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/github.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/github.md
@@ -221,7 +221,6 @@ Port's GitHub integration requires the following permissions:
   - **Deployments:** Readonly.
   - **Environments:** Readonly.
   - **Code scanning alerts:** Readonly.
-  -
 
 - Organization permissions:
 


### PR DESCRIPTION
# Description

Removed a redundant empty bullet in Github Permissions

## Updated docs pages

- Github (`/docs/build-your-software-catalog/sync-data-to-catalog/git/github/github.md`)

![image](https://github.com/port-labs/port-docs/assets/77775/49220afa-a1c9-4e84-9308-96c3bd4daf10)
