### PR TITLE
changes to dynamic permissions doc

### DIFF
--- a/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
+++ b/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
@@ -8,7 +8,7 @@ Port allows users to set dynamic permissions for both executing and approving ex
 - the ability to query the software catalog
 - the ability to set conditions based on queries of the software catalog
 
-This is a powerful feature that allows you to define your own logic based on any piece of data in your software catalog. Prior to defining dynamic permissions for a self-service action, Port recommends:
+This is a powerful feature that allows you to define your own logic based on any piece of data in your software catalog. Prior to defining dynamic permissions for a self-service action, we recommend:
 - clearly defining which users should be allowed to perform this action
 - clearly defining which users should be allowed to approve this action
 - ensuring that your software catalog contains the necessary blueprints and properties to support the dynamic permissions

--- a/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
+++ b/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
@@ -6,7 +6,7 @@ import TabItem from "@theme/TabItem"
 Port allows users to set dynamic permissions for both executing and approving execution of self-service actions. To support these dynamic permission, Port offers the following to users within the JSON configuration of any given self-service action:
 - The organization's full software catalog as defined in Port (to provide necessary context to the self-service action).
 - The ability to query the software catalog.
-- the ability to set conditions based on queries of the software catalog
+- The ability to set conditions based on queries of the software catalog.
 
 This is a powerful feature that allows you to define your own logic based on any piece of data in your software catalog. Prior to defining dynamic permissions for a self-service action, we recommend:
 - clearly defining which users should be allowed to perform this action

--- a/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
+++ b/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
@@ -11,7 +11,7 @@ Port allows users to set dynamic permissions for both executing and approving ex
 This is a powerful feature that allows you to define your own logic based on any piece of data in your software catalog. Prior to defining dynamic permissions for a self-service action, we recommend:
 - Clearly defining which users should be allowed to perform this action.
 - Clearly defining which users should be allowed to approve this action.
-- ensuring that your software catalog contains the necessary blueprints and properties to support the dynamic permissions
+- Ensuring that your software catalog contains the necessary blueprints and properties to support the dynamic permissions.
 
 ## Potential use-cases
 

--- a/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
+++ b/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
@@ -76,7 +76,7 @@ Under each of these two keys, you can add a `policy` key, which allows you to us
       "queries": {
         "query_name": {
           "rules": [
-              // Your rule(s) logic here
+              // Your rule/s logic here
             ],
             "combinator": "and"
         }

--- a/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
+++ b/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
@@ -9,7 +9,7 @@ Port allows users to set dynamic permissions for both executing and approving ex
 - The ability to set conditions based on queries of the software catalog.
 
 This is a powerful feature that allows you to define your own logic based on any piece of data in your software catalog. Prior to defining dynamic permissions for a self-service action, we recommend:
-- clearly defining which users should be allowed to perform this action
+- Clearly defining which users should be allowed to perform this action.
 - clearly defining which users should be allowed to approve this action
 - ensuring that your software catalog contains the necessary blueprints and properties to support the dynamic permissions
 

--- a/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
+++ b/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
@@ -4,7 +4,7 @@ import TabItem from "@theme/TabItem"
 # Dynamic permissions
 
 Port allows users to set dynamic permissions for both executing and approving execution of self-service actions. To support these dynamic permission, Port offers the following to users within the JSON configuration of any given self-service action:
-- the organization's full software catalog as defined in Port (to provide necessary context to the self-service action)
+- The organization's full software catalog as defined in Port (to provide necessary context to the self-service action).
 - the ability to query the software catalog
 - the ability to set conditions based on queries of the software catalog
 

--- a/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
+++ b/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
@@ -10,7 +10,7 @@ Port allows users to set dynamic permissions for both executing and approving ex
 
 This is a powerful feature that allows you to define your own logic based on any piece of data in your software catalog. Prior to defining dynamic permissions for a self-service action, we recommend:
 - Clearly defining which users should be allowed to perform this action.
-- clearly defining which users should be allowed to approve this action
+- Clearly defining which users should be allowed to approve this action.
 - ensuring that your software catalog contains the necessary blueprints and properties to support the dynamic permissions
 
 ## Potential use-cases

--- a/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
+++ b/docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem"
 
 Port allows users to set dynamic permissions for both executing and approving execution of self-service actions. To support these dynamic permission, Port offers the following to users within the JSON configuration of any given self-service action:
 - The organization's full software catalog as defined in Port (to provide necessary context to the self-service action).
-- the ability to query the software catalog
+- The ability to query the software catalog.
 - the ability to set conditions based on queries of the software catalog
 
 This is a powerful feature that allows you to define your own logic based on any piece of data in your software catalog. Prior to defining dynamic permissions for a self-service action, we recommend:


### PR DESCRIPTION
# Description

This PR attempts to shed more light on the levers available to prospects and customers who want to configure dynamic permissions for their own self-service actions. The complete example provided is a great one, and I did the following to bolster this strong example:
- added comments in the JSON examples
- switched JSON comment formatting from `#` to `//` to improve readability
- refined the description in the opening `# Dynamic permissions` section
- rearranged the `### Guidelines` to be more prominent and give the user an earlier understanding of the primitives available to them in dynamic permissions
- provided an additional "potential use case"
- added a section called `### Breaking down the `conditions` query from the example permissions JSON`, which guides the user through the example condition provided with more detailed explanations

Future additions should include example JSON blocks for each query and condition, so that users may see what properties are available to them when constructing queries and setting conditions.

## Updated docs pages

- Dynamic permissions (`docs/create-self-service-experiences/set-self-service-actions-rbac/dynamic-permissions.md`)
