### PR TITLE
[PORT-8328] [GCP] Aligned gcp docs with new removed versioned resources

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/cloud_resource/_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/cloud_resource/_port_app_config.mdx
@@ -1,36 +1,51 @@
 <details>
 
 <summary>Mapping configuration for cloud resources</summary>
-:::tip Cloud resource kind
-The `cloudResource` kind is a generic kind that can be used to map most cloud resources.
 
-The mapping requires passing the resource kind as a parameter inside the `resourceKinds` object.
-
-
-It is possible that some of the kinds that you want to export are not in this example, head to the bottom of the page to see how to add them.
-:::
 ```yaml showLineNumbers
 resources:
-  - kind: cloudResource
+  - kind: container.googleapis.com/Cluster
     selector:
-      query: 'true'
-      resourceKinds:
-        [
-          "compute.googleapis.com/Disk",
-          "pubsub.googleapis.com/Subscription",
-          "iam.googleapis.com/ServiceAccount",
-        ]
+      query: "true"
     port:
       entity:
         mappings:
           identifier: ".name"
-          title: ".display_name"
+          title: '.name | split("/") | last'
           blueprint: '"gcpCloudResource"'
           properties:
-            type: ".asset_type"
+            type: '.name | split("/") | .[-2]'
             location: ".location"
           relations:
-            project: ".project"
+            project: ".__project.name"
+  - kind: cloudfunctions.googleapis.com/CloudFunction
+    selector:
+      query: "true"
+    port:
+      entity:
+        mappings:
+          identifier: ".name"
+          title: '.name | split("/") | last'
+          blueprint: '"gcpCloudResource"'
+          properties:
+            type: '.name | split("/") | .[-2]'
+            location: ".location"
+          relations:
+            project: ".__project.name"
+  - kind: pubsub.googleapis.com/Topic
+    selector:
+      query: "true"
+    port:
+      entity:
+        mappings:
+          identifier: ".name"
+          title: '.name | split("/") | last'
+          blueprint: '"gcpCloudResource"'
+          properties:
+            type: '.name | split("/") | .[-2]'
+            location: ".location"
+          relations:
+            project: ".__project.name"
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/compute_resources/_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/compute_resources/_port_app_config.mdx
@@ -13,17 +13,17 @@ resources:
       entity:
         mappings:
           identifier: ".name"
-          title:  ".versioned_resources | max_by(.version).resource | .name"
+          title:  ".name | split("/") | last"
           blueprint: '"gcpAutoScaler"'
           properties:
             location: .location
-            description: ".versioned_resources | max_by(.version).resource | .description"
-            minNumReplicas: ".versioned_resources | max_by(.version).resource | .autoscalingPolicy.minNumReplicas"
-            maxNumReplicas: ".versioned_resources | max_by(.version).resource | .autoscalingPolicy.maxNumReplicas"
-            recommendedSize: ".versioned_resources | max_by(.version).resource | .recommendedSize"
-            target: ".versioned_resources | max_by(.version).resource | .target"
+            description: ".description"
+            minNumReplicas: ".autoscalingPolicy.minNumReplicas"
+            maxNumReplicas: ".autoscalingPolicy.maxNumReplicas"
+            recommendedSize: ".recommendedSize"
+            target: ".target"
           relations:
-            project: ".project"
+            project: ".__project.name"
   - kind: compute.googleapis.com/Firewall
     selector:
       query: "true"
@@ -31,18 +31,18 @@ resources:
       entity:
         mappings:
           identifier: ".name"
-          title:  ".versioned_resources | max_by(.version).resource | .name"
+          title:  ".name | split("/") | last"
           blueprint: '"gcpFirewall"'
           properties:
             location: .location
-            network: ".versioned_resources | max_by(.version).resource | .network"
-            destinationRanges: ".versioned_resources | max_by(.version).resource | .destinationRanges"
-            sourceRanges: ".versioned_resources | max_by(.version).resource | .sourceRanges"
-            priority: ".versioned_resources | max_by(.version).resource | .priority"
-            allowed: ".versioned_resources | max_by(.version).resource | .allowed"
-            denied: ".versioned_resources | max_by(.version).resource | .denied"
+            network: ".network"
+            destinationRanges: ".destinationRanges"
+            sourceRanges: ".sourceRanges"
+            priority: ".priority"
+            allowed: ".allowed"
+            denied: ".denied"
           relations:
-            project: ".project"
+            project: ".__project.name"
   - kind: compute.googleapis.com/Subnetwork
     selector:
       query: "true"
@@ -50,17 +50,17 @@ resources:
       entity:
         mappings:
           identifier: ".name"
-          title:  ".versioned_resources | max_by(.version).resource | .name"
+          title:  ".name | split("/") | last"
           blueprint: '"gcpSubnetwork"'
           properties:
             location: .location
-            privateIpGoogleAccess: ".versioned_resources | max_by(.version).resource | .privateIpGoogleAccess"
-            internalIpv6Prefix: ".versioned_resources | max_by(.version).resource | .internalIpv6Prefix"
-            externalIpv6Prefix: ".versioned_resources | max_by(.version).resource | .externalIpv6Prefix"
-            ipCidrRange: ".versioned_resources | max_by(.version).resource | .ipCidrRange"
-            description: ".versioned_resources | max_by(.version).resource | .description"
+            privateIpGoogleAccess: ".privateIpGoogleAccess"
+            internalIpv6Prefix: ".internalIpv6Prefix"
+            externalIpv6Prefix: ".externalIpv6Prefix"
+            ipCidrRange: ".ipCidrRange"
+            description: ".description"
           relations:
-            project: ".project"
+            project: ".__project.name"
   - kind: compute.googleapis.com/Instance
     selector:
       query: "true"
@@ -68,16 +68,16 @@ resources:
       entity:
         mappings:
           identifier: ".name"
-          title:  ".versioned_resources | max_by(.version).resource | .name"
+          title:  ".name | split("/") | last"
           blueprint: '"gcpComputeInstance"'
           properties:
             location: .location
-            machineType: ".versioned_resources | max_by(.version).resource | .machineType"
-            subnetworks: ".versioned_resources | max_by(.version).resource | .networkInterfaces[].subnetwork"
-            cpuPlatform: ".versioned_resources | max_by(.version).resource | .cpuPlatform"
-            selfLink: ".versioned_resources | max_by(.version).resource | .selfLink"
+            machineType: ".machineType"
+            subnetworks: ".networkInterfaces[].subnetwork"
+            cpuPlatform: ".cpuPlatform"
+            selfLink: ".selfLink"
           relations:
-            project: ".project"
+            project: ".__project.name"
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/examples.md
@@ -38,10 +38,6 @@ The Resources below have a relation to the Project, so the creation of the [Proj
 
 <CloudResourceAppConfig/>
 
-Here are the API references we used to create those blueprints and app config:
-
-- [Cloud Asset](https://cloud.google.com/asset-inventory/docs/reference/rest/v1/Asset)
-
 ## Mapping Extra Resources
 
 The resources in this page are only a few of the resources that the GCP Integration supports.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/mapping_extra_resources.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/mapping_extra_resources.md
@@ -40,12 +40,8 @@ A few examples:
 Create an integration configuration for the resource. The integration configuration is a YAML file that describes the ETL process to load data into the developer portal.
 
 #### Digesting values
-As you may see, some of the properties are digested using `.versioned_resources | max_by(.version).resource | <property_value>`. This is done, because the Cloud Assets contains all of the available versions of the resource within each inventory item, so that's why we take the most recent version of the asset in the inventory, and from that version we take the property value.
-All of the other properties, which are not versioned, are properties we digest directly from the asset in the Asset inventory, which are all listed [here](https://cloud.google.com/asset-inventory/docs/reference/rest/v1/Asset). These don't have multiple versions, and so are directly digested.
 
-:::warning Resources not digested from Asset Inventory
-   The `cloudresourcemanager.googleapis.com/Folder`, `cloudresourcemanager.googleapis.com/Organization`, `cloudresourcemanager.googleapis.com/Project`, and `pubsub.googleapis.com/Topic` are fetched directly from Google Cloud's API, not using the Asset Inventory. Therefore, access their properties directly, without using the jq command specified above.
-:::
+All properties from your [supported resource]((https://cloud.google.com/asset-inventory/docs/supported-asset-types)) REST API representation are available. Additionally, we inject a `.__project` field that represents the latest representation of the `project` containing the resource.
 
 <ComputeAppConfig/>
 
@@ -91,16 +87,16 @@ All of the other properties, which are not versioned, are properties we digest d
       entity:
         mappings: # Mappings between one GCP object to a Port entity. Each value is a JQ query.
           identifier: ".name"
-          title:  ".versioned_resources | max_by(.version).resource | .name"
+          title: ".name | split("/") | last"
           blueprint: '"gcpComputeInstance"'
           properties:
             location: .location
-            machineType: ".versioned_resources | max_by(.version).resource | .machineType"
-            subnetworks: ".versioned_resources | max_by(.version).resource | .networkInterfaces[].subnetwork"
-            cpuPlatform: ".versioned_resources | max_by(.version).resource | .cpuPlatform"
-            selfLink: ".versioned_resources | max_by(.version).resource | .selfLink"
+            machineType: ".machineType"
+            subnetworks: ".networkInterfaces[].subnetwork"
+            cpuPlatform: ".cpuPlatform"
+            selfLink: ".selfLink"
           relations:
-            project: ".project"
+            project: ".__project.name"
   		# highlight-end
   ```
 
@@ -119,7 +115,7 @@ All of the other properties, which are not versioned, are properties we digest d
         ```yaml showLineNumbers
         mappings:
         	# highlight-start
-          title:  ".versioned_resources | max_by(.version).resource | .name"
+          title: ".name | split("/") | last"
         	# highlight-end
         ```
       - The `blueprint` field describes the Port blueprint to be used to create the Port entity. This field is required for all resources.
@@ -135,11 +131,11 @@ All of the other properties, which are not versioned, are properties we digest d
         ```yaml showLineNumbers
         	mappings:
           identifier: ".name"
-            title:  ".versioned_resources | max_by(.version).resource | .name"
+            title: ".name | split("/") | last"
             blueprint: '"gcpComputeInstance"'
         		# highlight-start
         		properties:
         			location: .location
-              machineType: ".versioned_resources | max_by(.version).resource | .machineType"
+              machineType: ".machineType"
         		# highlight-end
         ```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/mapping_extra_resources.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/mapping_extra_resources.md
@@ -41,7 +41,7 @@ Create an integration configuration for the resource. The integration configurat
 
 #### Digesting values
 
-All properties from your [supported resource]((https://cloud.google.com/asset-inventory/docs/supported-asset-types)) REST API representation are available. Additionally, we inject a `.__project` field that represents the latest representation of the `project` containing the resource.
+All properties from your [supported resource](https://cloud.google.com/asset-inventory/docs/supported-asset-types)REST API representation are available. Additionally, we inject a `.__project` field that represents the latest representation of the `project` containing the resource.
 
 <ComputeAppConfig/>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/gcp.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/gcp.md
@@ -55,15 +55,15 @@ resources:
           # Transform & Load
           # highlight-start
           identifier: '.name'
-          title: '.versioned_resources | max_by(.version).resource | .name'
+          title: ".name | split("/") | last"
           blueprint: '"gcpPubSubSubscription"'
           properties:
             location: .location
-            topicMesssageRetentionDuration: ".versioned_resources | max_by(.version).resource | .topicMessageRetentionDuration"
-            pushConfig: ".versioned_resources | max_by(.version).resource | .pushConfig"
-            retainAckedMessages: ".versioned_resources | max_by(.version).resource | .retainAckedMessages"
+            topicMesssageRetentionDuration: ".topicMessageRetentionDuration"
+            pushConfig: ".pushConfig"
+            retainAckedMessages: ".retainAckedMessages"
          relations:
-            project: ".project"
+            project: ".__project.name"
           # highlight-end
 ```
 
@@ -117,15 +117,15 @@ The integration configuration is a YAML file that describes the ETL process to l
       entity:
         mappings:
           identifier: '.name'
-          title: '.versioned_resources | max_by(.version).resource | .name'
+          title: ".name | split("/") | last"
           blueprint: '"gcpPubSubSubscription"'
           properties:
             location: .location
-            topicMesssageRetentionDuration: ".versioned_resources | max_by(.version).resource | .topicMessageRetentionDuration"
-            pushConfig: ".versioned_resources | max_by(.version).resource | .pushConfig"
-            retainAckedMessages: ".versioned_resources | max_by(.version).resource | .retainAckedMessages"
+            topicMesssageRetentionDuration: ".topicMessageRetentionDuration"
+            pushConfig: ".pushConfig"
+            retainAckedMessages: ".retainAckedMessages"
          relations:
-            project: ".project"
+            project: ".__project.name"
         # highlight-end
   ```
   - The `entity` field describes the Port entity to be created from the GCP resource.
@@ -140,15 +140,15 @@ The integration configuration is a YAML file that describes the ETL process to l
          mappings:
           # Transform & Load
           identifier: '.name'
-          title: '.versioned_resources | max_by(.version).resource | .name'
+          title: ".name | split("/") | last"
           blueprint: '"gcpPubSubSubscription"'
           properties:
             location: .location
-            topicMesssageRetentionDuration: ".versioned_resources | max_by(.version).resource | .topicMessageRetentionDuration"
-            pushConfig: ".versioned_resources | max_by(.version).resource | .pushConfig"
-            retainAckedMessages: ".versioned_resources | max_by(.version).resource | .retainAckedMessages"
+            topicMesssageRetentionDuration: ".topicMessageRetentionDuration"
+            pushConfig: ".pushConfig"
+            retainAckedMessages: ".retainAckedMessages"
          relations:
-            project: ".project"
+            project: ".__project.name"
           # highlight-end
     ```
 


### PR DESCRIPTION
# Description

Following the change in mapping in the GCP Ocean integration, a realignment of the GCP mapping docs had to be changed. Now removing versioning from the resources + removal of the cloud resource kind 

## Updated docs pages

Please also include the path for the updated docs

- GCP (`/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/`)
- GCP examples (`/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/`)
- Mapping extra resources (`/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/mapping_extra_resources`)
