### PR TITLE
Update all search operators

### DIFF
--- a/docs/promote-scorecards/promote-scorecards.md
+++ b/docs/promote-scorecards/promote-scorecards.md
@@ -276,6 +276,7 @@ specified [`combinator`](#combinator):
 | `<`                | `String`, `Number`                               | checks if the rule value is less than the entity value                |
 | `>`                | `String`, `Number`                               | checks if the rule value is greater than the entity value             |
 | `contains`         | `String`, `Number`                               | checks if the rule value is contained within the entity value         |
+| `containsAny`      | `String`, `Number`                               | checks if any of the specified strings exist in the target array      |
 | `doesNotContains`  | `String`, `Number`                               | checks if the rule value is not contained within the entity value     |
 | `endsWith`         | `String`, `Number`                               | checks if the rule value ends with the entity value                   |
 | `doesNotEndsWith`  | `String`, `Number`                               | checks if the rule value does not end with the entity value           |

--- a/docs/search-and-query/search-and-query.md
+++ b/docs/search-and-query/search-and-query.md
@@ -158,7 +158,12 @@ Port has 2 types of search rule operators:
 {label: "Between", value: "between"},
 {label: "notBetween", value: "notBetween"},
 {label: "Contains", value: "contains"},
+{label: "DoesNotContains", value: "doesNotContains"},
 {label: "ContainsAny", value: "containsAny"},
+{label: "beginsWith", value: "beginsWith"},
+{label: "DoesNotBeginsWith", value: "doesNotBeginsWith"},
+{label: "endsWith", value: "endsWith"},
+{label: "DoesNotEndsWith", value: "doesNotEndsWith"},
 {label: "In", value: "in"}
 ]}>
 
@@ -421,6 +426,21 @@ The `contains` operator checks if the specified substring exists in the specifie
 
 </TabItem>
 
+
+<TabItem value="doesNotContains">
+
+The `contains` operator checks if the specified value **does not** exists in the specified property:
+
+```json showLineNumbers
+{
+  "operator": "doesNotContains",
+  "property": "myStringProperty",
+  "value": "otherValue"
+}
+```
+
+</TabItem>
+
 <TabItem value="containsAny">
 
 The `containsAny` operator checks if **any** of the specified strings exist in the target array:
@@ -434,6 +454,68 @@ The `containsAny` operator checks if **any** of the specified strings exist in t
 ```
 
 </TabItem>
+
+<TabItem value="beginsWith">
+
+The `beginsWith` operator checks if the specified property starts with the specified value**
+
+```json showLineNumbers
+{
+  "operator": "beginsWith",
+  "property": "myStringProperty",
+  "value": "myString"
+}
+```
+
+</TabItem>
+
+
+
+<TabItem value="doesNotBeginsWith">
+
+The `doesNotBeginsWith` operator checks if the specified property **does not** start with the specified value
+
+```json showLineNumbers
+{
+  "operator": "doesNotBeginsWith",
+  "property": "myStringProperty",
+  "value": "otherValue"
+}
+```
+
+</TabItem>
+
+
+<TabItem value="endsWith">
+
+The `endsWith` operator checks if the specified property ends with the specified value
+
+```json showLineNumbers
+{
+  "operator": "endsWith",
+  "property": "myStringProperty",
+  "value": "myString"
+}
+```
+
+</TabItem>
+
+
+
+<TabItem value="doesNotEndsWith">
+
+The `doesNotEndsWith` operator checks if the specified property **does not** end with the specified value
+
+```json showLineNumbers
+{
+  "operator": "doesNotEndsWith",
+  "property": "myStringProperty",
+  "value": "otherValue"
+}
+```
+
+</TabItem>
+
 
 <TabItem value="in">
 


### PR DESCRIPTION
# Description

Add missing search operators (`doesNotContains|endsWith|doesNotEndsWith|beginsWith|doesNotBeginsWith`)

## Updated docs pages

Please also include the path for the updated docs

- Search and Query (`/search-and-query/#operators`)
