### PR TITLE
Fix typo in doesNot operator

### DIFF
--- a/docs/promote-scorecards/promote-scorecards.md
+++ b/docs/promote-scorecards/promote-scorecards.md
@@ -267,23 +267,23 @@ specified [`combinator`](#combinator):
 
 #### Available operators
 
-| Operator           | Supported Types                                  | Description                                                           |
-|--------------------|--------------------------------------------------|-----------------------------------------------------------------------|
-| `=`                | `String`, `Number`, `Boolean`                    | checks if the rule value is equal to the entity value                 |
-| `!=`               | `String`, `Number`, `Boolean`                    | checks if the rule value is not equal to the entity value             |
-| `<=`               | `String`, `Number`                               | checks if the rule value is less than or equal to the entity value    |
-| `>=`               | `String`, `Number`                               | checks if the rule value is greater than or equal to the entity value |
-| `<`                | `String`, `Number`                               | checks if the rule value is less than the entity value                |
-| `>`                | `String`, `Number`                               | checks if the rule value is greater than the entity value             |
-| `contains`         | `String`, `Number`                               | checks if the rule value is contained within the entity value         |
-| `containsAny`      | `String`, `Number`                               | checks if any of the specified strings exist in the target array      |
-| `doesNotContains`  | `String`, `Number`                               | checks if the rule value is not contained within the entity value     |
-| `endsWith`         | `String`, `Number`                               | checks if the rule value ends with the entity value                   |
-| `doesNotEndsWith`  | `String`, `Number`                               | checks if the rule value does not end with the entity value           |
-| `beginsWith`       | `String`, `Number`                               | checks if the rule value begins with the entity value                 |
-| `doesNotBeginWith` | `String`, `Number`                               | checks if the rule value does not begin with the entity value         |
-| `isEmpty`          | `String`, `Number`, `Boolean`, `Array`, `Object` | checks if the rule value is an empty string, array, or object         |
-| `isNotEmpty`       | `String`, `Number`, `Boolean`, `Array`, `Object` | checks if the rule value is not an empty string, array, or object     |
+| Operator            | Supported Types                                  | Description                                                           |
+|---------------------|--------------------------------------------------|-----------------------------------------------------------------------|
+| `=`                 | `String`, `Number`, `Boolean`                    | checks if the rule value is equal to the entity value                 |
+| `!=`                | `String`, `Number`, `Boolean`                    | checks if the rule value is not equal to the entity value             |
+| `<=`                | `String`, `Number`                               | checks if the rule value is less than or equal to the entity value    |
+| `>=`                | `String`, `Number`                               | checks if the rule value is greater than or equal to the entity value |
+| `<`                 | `String`, `Number`                               | checks if the rule value is less than the entity value                |
+| `>`                 | `String`, `Number`                               | checks if the rule value is greater than the entity value             |
+| `contains`          | `String`, `Number`                               | checks if the rule value is contained within the entity value         |
+| `containsAny`       | `String`, `Number`                               | checks if any of the specified strings exist in the target array      |
+| `doesNotContains`   | `String`, `Number`                               | checks if the rule value is not contained within the entity value     |
+| `endsWith`          | `String`, `Number`                               | checks if the rule value ends with the entity value                   |
+| `doesNotEndsWith`   | `String`, `Number`                               | checks if the rule value does not end with the entity value           |
+| `beginsWith`        | `String`, `Number`                               | checks if the rule value begins with the entity value                 |
+| `doesNotBeginsWith` | `String`, `Number`                               | checks if the rule value does not begin with the entity value         |
+| `isEmpty`           | `String`, `Number`, `Boolean`, `Array`, `Object` | checks if the rule value is an empty string, array, or object         |
+| `isNotEmpty`        | `String`, `Number`, `Boolean`, `Array`, `Object` | checks if the rule value is not an empty string, array, or object     |
 
 ## Scorecard total level calculation
 


### PR DESCRIPTION
# Description

Fix a typo in the does not search / scorecard operator

## Updated docs pages

- Promote Scorecards (`/promote-scorecards/promote-scorecards`)
