### PR TITLE
Removing trailing commas from backend example

### DIFF
--- a/docs/guides-and-tutorials/scaffold-a-new-service.md
+++ b/docs/guides-and-tutorials/scaffold-a-new-service.md
@@ -80,9 +80,9 @@ Fill out the form with your values:
   ```json showLineNumbers
   {
     "port_context": {
-        "runId": "{{ .run.id }}",
+        "runId": "{{ .run.id }}"
     },
-    "service_name": "{{ .inputs.service_name }}",
+    "service_name": "{{ .inputs.service_name }}"
   }
   ```
 


### PR DESCRIPTION
# Description

If copied and pasted, this backend example does not work due to two trailing commas. When removed, the backend works.

## Updated docs pages

Please also include the path for the updated docs

- docs/guides-and-tutorials/scaffold-a-new-service.md
