### PR TITLE
fix: GitOps guide - domain identifier param name in the input form

### DIFF
--- a/docs/guides-and-tutorials/let-developers-enrich-services-using-gitops.md
+++ b/docs/guides-and-tutorials/let-developers-enrich-services-using-gitops.md
@@ -502,7 +502,7 @@ enrichService:
     - git config --global user.email "gitRunner@git.com"
     - git config --global user.name "Git Runner"
     - SERVICE_IDENTIFIER=$(echo $PAYLOAD | jq -r '.port_context.entity')
-    - DOMAIN_IDENTIFIER=$(echo $PAYLOAD | jq -r '.domain')
+    - DOMAIN_IDENTIFIER=$(echo $PAYLOAD | jq -r '.domain.identifier')
     - SERVICE_TYPE=$(echo $PAYLOAD | jq -r '.type')
     - SERVICE_LIFECYCLE=$(echo $PAYLOAD | jq -r '.lifecycle')
     - git clone https://:${GITLAB_ACCESS_TOKEN}@gitlab.com/${CI_PROJECT_PATH}.git


### PR DESCRIPTION
# Description

In the guide describing the usage of `port.yml` file with GitOps approach, when the `domain` entity is pushed from the user's form to the Gitlab pipeline to create a new port.yml file, the full `domain` entity is populated inside the file instead of only the identifier, as needed for reletaion to work.

## Updated docs pages

Please also include the path for the updated docs

- Let developers enrich services using Gitops (`/guides-and-tutorials/let-developers-enrich-services-using-gitops/`)
