### PR TITLE
PORT 8756 aws integration add use get resource api to docs

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources.md
@@ -204,7 +204,7 @@ resources:
 
 **Note: Using the `useGetResourceAPI` option will make each resync run slower.**
 
-:::tip
+:::tip Get an example of the AWS resource properties
 To get an example of the AWS resource properties, you can use the [AWS Cloud Control API](https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/what-is-cloudcontrolapi.html) to get the resource properties.
 
 For example for the `AWS::Lambda::Function` resource, you can use the following command to get the resource properties:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources.md
@@ -164,7 +164,8 @@ Create an integration configuration for the resource. The integration configurat
 
 #### `useGetResourceAPI` property
 
-- By default the integration uses the [`CloudControl:ListResources`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/list-resources.html) API to get the resources. The integration can also enrich each resource by running [`CloudControl:GetResource`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/get-resource.html) on each resource, you can use this by enabling `useGetResourceAPI` option.
+- By default the integration uses the [`CloudControl:ListResources`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/list-resources.html) API to get the resources. The integration can also enrich each resource by running [`CloudControl:GetResource`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/get-resource.html) on each resource, you can use this by enabling `useGetResourceAPI` option.  
+
   The `useGetResourceAPI` option is only available for resources that support the `CloudControl:GetResource` API.
 
 ```yaml showLineNumbers

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources.md
@@ -162,13 +162,54 @@ Create an integration configuration for the resource. The integration configurat
                   # highlight-end
             ```
 
-    :::tip
-    To get an example of the AWS resource properties, you can use the [AWS Cloud Control API](https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/what-is-cloudcontrolapi.html) to get the resource properties.
+#### `useGetResourceAPI` property
 
-    For example for the `AWS::Lambda::Function` resource, you can use the following command to get the resource properties:
+- By default the integration uses the [`CloudControl:ListResources`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/list-resources.html) API to get the resources. The integration can also enrich each resource by running [`CloudControl:GetResource`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/get-resource.html) on each resource, you can use this by enabling `useGetResourceAPI` option.
+  The `useGetResourceAPI` option is only available for resources that support the `CloudControl:GetResource` API.
 
-    ```bash
-    aws cloudcontrol list-resources --type-name AWS::Lambda::Function --max-items 1 | jq .ResourceDescriptions
-    ```
+```yaml showLineNumbers
+resources:
+  - kind: AWS::Lambda::Function
+    selector:
+      query: 'true' # JQ boolean query. If evaluated to false - skip syncing the object.
+      # highlight-start
+      useGetResourceAPI: 'true'
+      # highlight-end
+    port:
+      entity:
+        mappings: # Mappings between one AWS object to a Port entity. Each value is a JQ query.
+          identifier: '.Identifier'
+          title: '.Properties.FunctionName'
+          blueprint: 'lambda'
+          properties:
+            kind: '.__Kind'
+            region: '.__Region'
+            link: "'https://console.aws.amazon.com/go/view?arn=' + .Properties.Arn"
+            description: '.Properties.Description'
+            memorySize: '.Properties.MemorySize'
+            ephemeralStorageSize: '.Properties.EphemeralStorage.Size'
+            timeout: '.Properties.Timeout'
+            runtime: '.Properties.Runtime'
+            packageType: '.Properties.PackageType'
+            environment: '.Properties.Environment'
+            architectures: '.Properties.Architectures'
+            layers: '.Properties.Layers'
+            tags: '.Properties.Tags'
+            iamRole: "'https://console.aws.amazon.com/go/view?arn=' + .Properties.Role"
+            arn: '.Properties.Arn'
+          relations:
+            account: '.__AccountId'
+```
 
-    :::
+**Note: Using the `useGetResourceAPI` option will make each resync run slower.**
+
+:::tip
+To get an example of the AWS resource properties, you can use the [AWS Cloud Control API](https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/what-is-cloudcontrolapi.html) to get the resource properties.
+
+For example for the `AWS::Lambda::Function` resource, you can use the following command to get the resource properties:
+
+```bash
+aws cloudcontrol list-resources --type-name AWS::Lambda::Function --max-items 1 | jq .ResourceDescriptions
+```
+
+:::

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources.md
@@ -164,7 +164,7 @@ Create an integration configuration for the resource. The integration configurat
 
 #### `useGetResourceAPI` property
 
-- By default the integration uses the [`CloudControl:ListResources`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/list-resources.html) API to get the resources. The integration can also enrich each resource by running [`CloudControl:GetResource`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/get-resource.html) on each resource, you can use this by enabling `useGetResourceAPI` option.  
+- By default the integration uses the [`CloudControl:ListResources`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/list-resources.html) API to get the resources. The integration can also enrich each resource by running [`CloudControl:GetResource`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/get-resource.html) on each resource, you can use this by enabling `useGetResourceAPI` option.
 
   The `useGetResourceAPI` option is only available for resources that support the `CloudControl:GetResource` API.
 
@@ -202,7 +202,7 @@ resources:
             account: '.__AccountId'
 ```
 
-**Note: Using the `useGetResourceAPI` option will make each resync run slower.**
+**Note: Using the `useGetResourceAPI` option will make each resync run slower and use a lot more memory and cpu so you might want to add memory and cpu limits.**
 
 :::tip Get an example of the AWS resource properties
 To get an example of the AWS resource properties, you can use the [AWS Cloud Control API](https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/what-is-cloudcontrolapi.html) to get the resource properties.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installation.md
@@ -2,10 +2,60 @@
 sidebar_position: 1
 ---
 
+import Tabs from "@theme/Tabs"
+import TabItem from "@theme/TabItem"
+
 # Installation
 
-The AWS integration is deployed using Terraform on AWS ECS cluster service.  
-It uses our Terraform [Ocean](https://ocean.getport.io) Integration Factory [module](https://registry.terraform.io/modules/port-labs/integration-factory/ocean/latest) to deploy the integration.
+## Permissions
+
+In order to successfully deploy the AWS integration, it's crucial to ensure that the user who deploys the integration in the AWS Organization has the appropriate access permissions to create all of the above resources.
+
+Choose one of the following installation methods:
+<Tabs groupId="installation-platforms" queryString="installation-platforms">
+<TabItem value="helm" label="Helm">
+The AWS integration is deployed using Helm on you cluster.
+You can check out the Helm chart [here](https://github.com/port-labs/helm-charts/tree/main/charts/port-ocean).
+
+## Prerequisites
+
+- [Helm 3](https://helm.sh/docs/intro/install/)
+- [A logged in aws CLI 2](https://aws.amazon.com/cli/)
+
+```bash
+helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
+helm upgrade --install aws port-labs/port-ocean \
+--set port.clientId="$PORT_CLIENT_ID"  \
+--set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
+--set port.baseUrl="https://api.getport.io"  \
+--set initializePortResources=true  \
+--set sendRawDataExamples=true  \
+--set integration.identifier="my-aws"  \
+--set integration.type="aws"  \
+--set integration.eventListener.type="POLLING"  \
+--set integration.config.liveEventsApiKey="$YOUR_CUSTOM_API_KEY" \
+--set integration.config.awsAccessKeyId="$AWS_ACCESS_KEY_ID" \
+--set integration.config.awsSecretAccessKey="$AWS_SECRET_ACCESS_KEY" \
+```
+
+### IRSA
+
+If you are using [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), you can set the following values, after [assigning the appropriate IAM role to the service account](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html):
+
+```bash
+--set podServiceAccount.name="$SERVICE_ACCOUNT" \
+```
+
+  </TabItem>
+  <TabItem value="terraform" label="Terraform">
+  The AWS integration is deployed using Terraform on AWS ECS cluster service.  
+  It uses our Terraform [Ocean](https://ocean.getport.io) Integration Factory [module](https://registry.terraform.io/modules/port-labs/integration-factory/ocean/latest) to deploy the integration.
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/downloads.html) >= 0.15.0
+- [A logged in aws CLI 2](https://aws.amazon.com/cli/)
+- [Certificate domain name (Optional)](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html)
 
 :::warning Live-Events
 This installation guide is for the AWS integration only.
@@ -13,6 +63,58 @@ It does not take into consideration the **live-events** infrastructure **which i
 The env variables referring to the live events (such as `LIVE_EVENTS_API_KEY`) are optional and can be removed if not needed.
 :::
 
+```bash
+	# Logging into you AWS account
+	aws sso login
+	# Copying the following module into a main.tf file
+	echo 'module "aws" {
+	source = "port-labs/integration-factory/ocean//examples/aws_container_app"
+	version = ">=0.0.24"
+	port = {
+		client_id = "$PORT_CLIENT_ID"
+		client_secret = "$PORT_CLIENT_SECRET_ID"
+		base_url = "https://api.getport.io"
+	}
+	initialize_port_resources = true # When set to true the integration will create default blueprints + JQ Mappings
+	integration = {
+		identifier = "my-aws-integration" # Change the identifier to describe your integration
+		config = {
+			live_events_api_key = "$YOUR_CUSTOM_API_KEY" # AWS API Key for custom events, used to validate the event source for real-time event updates.
+		}
+	}
+	event_listener = {
+		type = "POLLING"
+	}
+	allow_incoming_requests = true # Whether to allow incoming requests
+	create_default_sg = false # Whether to create the default security group
+	subnets = ["subnet-1","subnet-2","subnet-3"] # The subnets to deploy the LB to
+	vpc_id = "vpc-1" # The LB VPC ID
+	cluster_name = "port-ocean-aws-exporter" # The ECS cluster name
+	}' > main.tf
+	# Initializing Terraform and Providers
+	terraform init
+	# Creating the resources
+	terraform apply
+```
+
+<details>
+<summary>Variables</summary>
+| Variable | Description |
+| --- | --- |
+| subnets | List of subnet IDs where the ECS tasks will run.  |
+| port.client_id | The client ID for the Port integration.  |
+| port.client_secret | The client secret for the Port integration.  |
+| integration.identifier | The identifier for the integration.  |
+| integration.config.live_events_api_key | A user-defined API key for authenticating with the live events API, for example "my-secret".  |
+| integration.config.organization_role_arn (optional) | ARN of the role used to assume the organization role.  |
+| integration.config.account_read_role_name (optional) | Name of the role used to assume the read role in the account.  |
+| cluster_name (optional) | Name of the ECS cluster.  |
+| vpc_id | VPC ID where the cluster will be created.  |
+| initialize_port_resources | Boolean to initialize Port resources.  |
+| create_default_sg | Boolean to create a default security group.  |
+| allow_incoming_requests | Boolean to allow incoming requests to the ECS tasks.  |
+
+</details>
 ## Infrastructure
 
 The AWS integration uses the following AWS infrastructure:
@@ -32,75 +134,12 @@ The AWS integration uses the following AWS infrastructure:
       <img src='/img/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/live-events-diagram.svg' width='60%' border='1px' />
    </center>
 </details>
-
-## Prerequisites
-
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.15.0
-- [A logged in aws CLI 2](https://aws.amazon.com/cli/)
-- [Certificate domain name (Optional)](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html)
-- [Permissions (When running on-premise)](#permissions)
-
-## Permissions
-
-In order to successfully deploy the AWS integration, it's crucial to ensure that the user who deploys the integration in the AWS Organization has the appropriate access permissions to create all of the above resources.
-
-## Install using terraform
-
-1. Go to Port's [Data Sources](https://app.getport.io/settings/data-sources?section=EXPORTERS) and click on AWS.
-2. Edit and copy the installation command.
-3. Run the command in your terminal to deploy the AWS integration.
-
-## Install using Helm (Kubernetes)
-
-<details>
-<summary>Installation</summary>
-
-```bash
-helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
-helm upgrade --install aws port-labs/port-ocean \
-	--set port.clientId="$PORT_CLIENT_ID"  \
-	--set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
-	--set sendRawDataExamples=true  \
-	--set integration.identifier="my-aws"  \
-	--set integration.type="aws"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.config.liveEventsApiKey="<choose your api key>" \
-	--set integration.config.awsAccessKeyId="$AWS_ACCESS_KEY_ID" \
-	--set integration.config.awsSecretAccessKey="$AWS_SECRET_ACCESS_KEY" \
-```
-
-</details>
-
-## Manual installation (AWS)
-
-1. Create the infrastructure using the [AWS Console](https://aws.amazon.com/console/).
-2. For the ECS Service image use the following image: `ghcr.io/port-labs/port-ocean-aws:latest`.
-3. Add the following environment variables to the ECS Task Definition:
-<details>
-<summary>Environment Variables</summary>
-
-| Variable                                             | Description                                                                                                                                                                                                                                                          |
-| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `OCEAN__PORT__CLIENT_ID`                             | [The client ID of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API).                                                                                                                                    |
-| `OCEAN__PORT__CLIENT_SECRET`                         | [The client secret of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API).                                                                                                                                |
-| `OCEAN__PORT__BASE_URL`                              | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US                                                                                                                                                                              |
-| `OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY`    | (Optional) AWS API Key for live events, used to validate the event source for real-time event, it's value is completely up to you                                                                                                                                    |
-| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ROLE_ARN`  | [(Optional) AWS Organization Role ARN, in case the account the integration is installed on is not the root account, used to read organization accounts for multi-account access](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html). |
-| `OCEAN__INTEGRATION__CONFIG__ACCOUNT_READ_ROLE_NAME` | [(Optional) AWS Account Read Role Name, the role name used to read the account in which the integration is not installed on, used for multi-account access.](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html).                                        |
-| `OCEAN__EVENT_LISTENER`                              | [The event listener object](https://ocean.getport.io/framework/features/event-listener/).                                                                                                                                                                            |
-| `OCEAN__INTEGRATION__IDENTIFIER`                     | The identifier of the integration.                                                                                                                                                                                                                                   |
-| `OCEAN__INTEGRATION__TYPE`                           | should be set to `aws`.                                                                                                                                                                                                                                              |
-
-</details>
-
-## Manual installation (on-premise)
-
+</TabItem>
+<TabItem value="on-prem" label="On Premise">
 1. Create an IAM user with the following permissions:
-   - `arn:aws:iam::aws:policy/ReadOnlyAccess`
-   - `account:ListRegions`
-   - `sts:AssumeRole`
+- `arn:aws:iam::aws:policy/ReadOnlyAccess`
+- `account:ListRegions`
+- `sts:AssumeRole`
 2. Run the following Docker image: `ghcr.io/port-labs/port-ocean-aws:latest`.
 3. (For live updates): expose the port `8000` to the internet.
 4. Add the following environment variables to the Docker container:
@@ -123,6 +162,8 @@ helm upgrade --install aws port-labs/port-ocean \
 | `OCEAN__INTEGRATION__TYPE`                           | should be set to `aws`.                                                                                                                                                                                                                                              |
 
 </details>
+</TabItem>
+</Tabs>
 
 ## Further Examples
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installation.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 The AWS integration is deployed using Terraform on AWS ECS cluster service.  
 It uses our Terraform [Ocean](https://ocean.getport.io) Integration Factory [module](https://registry.terraform.io/modules/port-labs/integration-factory/ocean/latest) to deploy the integration.
 
-:::warning
+:::warning Live-Events
 This installation guide is for the AWS integration only.
 It does not take into consideration the **live-events** infrastructure **which is optional**.
 The env variables referring to the live events (such as `LIVE_EVENTS_API_KEY`) are optional and can be removed if not needed.
@@ -44,13 +44,13 @@ The AWS integration uses the following AWS infrastructure:
 
 In order to successfully deploy the AWS integration, it's crucial to ensure that the user who deploys the integration in the AWS Organization has the appropriate access permissions to create all of the above resources.
 
-## install using terraform
+## Install using terraform
 
 1. Go to Port's [Data Sources](https://app.getport.io/settings/data-sources?section=EXPORTERS) and click on AWS.
 2. Edit and copy the installation command.
 3. Run the command in your terminal to deploy the AWS integration.
 
-## install using Helm (Kubernetes)
+## Install using Helm (Kubernetes)
 
 <details>
 <summary>Installation</summary>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installation.md
@@ -7,6 +7,12 @@ sidebar_position: 1
 The AWS integration is deployed using Terraform on AWS ECS cluster service.  
 It uses our Terraform [Ocean](https://ocean.getport.io) Integration Factory [module](https://registry.terraform.io/modules/port-labs/integration-factory/ocean/latest) to deploy the integration.
 
+:::warning
+This installation guide is for the AWS integration only.
+It does not take into consideration the **live-events** infrastructure **which is optional**.
+The env variables referring to the live events (such as `LIVE_EVENTS_API_KEY`) are optional and can be removed if not needed.
+:::
+
 ## Infrastructure
 
 The AWS integration uses the following AWS infrastructure:
@@ -80,7 +86,7 @@ helm upgrade --install aws port-labs/port-ocean \
 | `OCEAN__PORT__CLIENT_ID`                             | [The client ID of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API).                                                                                                                                    |
 | `OCEAN__PORT__CLIENT_SECRET`                         | [The client secret of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API).                                                                                                                                |
 | `OCEAN__PORT__BASE_URL`                              | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US                                                                                                                                                                              |
-| `OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY`    | (Optional) AWS API Key for custom events, used to validate the event source for real-time event updates.                                                                                                                                                             |
+| `OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY`    | (Optional) AWS API Key for live events, used to validate the event source for real-time event, it's value is completely up to you                                                                                                                                    |
 | `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ROLE_ARN`  | [(Optional) AWS Organization Role ARN, in case the account the integration is installed on is not the root account, used to read organization accounts for multi-account access](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html). |
 | `OCEAN__INTEGRATION__CONFIG__ACCOUNT_READ_ROLE_NAME` | [(Optional) AWS Account Read Role Name, the role name used to read the account in which the integration is not installed on, used for multi-account access.](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html).                                        |
 | `OCEAN__EVENT_LISTENER`                              | [The event listener object](https://ocean.getport.io/framework/features/event-listener/).                                                                                                                                                                            |
@@ -109,7 +115,7 @@ helm upgrade --install aws port-labs/port-ocean \
 | `OCEAN__PORT__BASE_URL`                              | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US                                                                                                                                                                              |
 | `OCEAN__INTEGRATION__CONFIG__AWS_ACCESS_KEY_ID`      | [The AWS Access Key ID of the IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html).                                                                                                                                                      |
 | `OCEAN__INTEGRATION__CONFIG__AWS_SECRET_ACCESS_KEY`  | [The AWS Secret Access Key of the IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html).                                                                                                                                                  |
-| `OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY`    | (Optional) AWS API Key for custom events, used to validate the event source for real-time event updates.                                                                                                                                                             |
+| `OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY`    | (Optional) AWS API Key for live events, used to validate the event source for real-time event, it's value is completely up to you                                                                                                                                    |
 | `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ROLE_ARN`  | [(Optional) AWS Organization Role ARN, in case the account the integration is installed on is not the root account, used to read organization accounts for multi-account access](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html). |
 | `OCEAN__INTEGRATION__CONFIG__ACCOUNT_READ_ROLE_NAME` | [(Optional) AWS Account Read Role Name, the role name used to read the account in which the integration is not installed on, used for multi-account access.](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html).                                        |
 | `OCEAN__EVENT_LISTENER`                              | [The event listener object](https://ocean.getport.io/framework/features/event-listener/).                                                                                                                                                                            |

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installation.md
@@ -38,11 +38,34 @@ The AWS integration uses the following AWS infrastructure:
 
 In order to successfully deploy the AWS integration, it's crucial to ensure that the user who deploys the integration in the AWS Organization has the appropriate access permissions to create all of the above resources.
 
-## Installation walkthrough using terraform
+## install using terraform
 
 1. Go to Port's [Data Sources](https://app.getport.io/settings/data-sources?section=EXPORTERS) and click on AWS.
 2. Edit and copy the installation command.
 3. Run the command in your terminal to deploy the AWS integration.
+
+## install using Helm (Kubernetes)
+
+<details>
+<summary>Installation</summary>
+
+```bash
+helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
+helm upgrade --install aws port-labs/port-ocean \
+	--set port.clientId="$PORT_CLIENT_ID"  \
+	--set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
+	--set port.baseUrl="https://api.getport.io"  \
+	--set initializePortResources=true  \
+	--set sendRawDataExamples=true  \
+	--set integration.identifier="my-aws"  \
+	--set integration.type="aws"  \
+	--set integration.eventListener.type="POLLING"  \
+	--set integration.config.liveEventsApiKey="<choose your api key>" \
+	--set integration.config.awsAccessKeyId="$AWS_ACCESS_KEY_ID" \
+	--set integration.config.awsSecretAccessKey="$AWS_SECRET_ACCESS_KEY" \
+```
+
+</details>
 
 ## Manual installation (AWS)
 
@@ -52,17 +75,18 @@ In order to successfully deploy the AWS integration, it's crucial to ensure that
 <details>
 <summary>Environment Variables</summary>
 
-| Variable | Description |
-| --- | --- |
-| `OCEAN__PORT__CLIENT_ID` | [The client ID of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API). |
-| `OCEAN__PORT__CLIENT_SECRET` | [The client secret of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API). |
-| `OCEAN__PORT__BASE_URL`                     | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US | 
-| `OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY` | (Optional) AWS API Key for custom events, used to validate the event source for real-time event updates. |
-| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ROLE_ARN` | [(Optional) AWS Organization Role ARN, in case the account the integration is installed on is not the root account, used to read organization accounts for multi-account access](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html). |
-| `OCEAN__INTEGRATION__CONFIG__ACCOUNT_READ_ROLE_NAME` | [(Optional) AWS Account Read Role Name, the role name used to read the account in which the integration is not installed on, used for multi-account access.](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html). |
-| `OCEAN__EVENT_LISTENER` | [The event listener object](https://ocean.getport.io/framework/features/event-listener/). |
-| `OCEAN__INTEGRATION__IDENTIFIER` | The identifier of the integration. |
-| `OCEAN__INTEGRATION__TYPE` | should be set to `aws`. |
+| Variable                                             | Description                                                                                                                                                                                                                                                          |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OCEAN__PORT__CLIENT_ID`                             | [The client ID of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API).                                                                                                                                    |
+| `OCEAN__PORT__CLIENT_SECRET`                         | [The client secret of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API).                                                                                                                                |
+| `OCEAN__PORT__BASE_URL`                              | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US                                                                                                                                                                              |
+| `OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY`    | (Optional) AWS API Key for custom events, used to validate the event source for real-time event updates.                                                                                                                                                             |
+| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ROLE_ARN`  | [(Optional) AWS Organization Role ARN, in case the account the integration is installed on is not the root account, used to read organization accounts for multi-account access](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html). |
+| `OCEAN__INTEGRATION__CONFIG__ACCOUNT_READ_ROLE_NAME` | [(Optional) AWS Account Read Role Name, the role name used to read the account in which the integration is not installed on, used for multi-account access.](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html).                                        |
+| `OCEAN__EVENT_LISTENER`                              | [The event listener object](https://ocean.getport.io/framework/features/event-listener/).                                                                                                                                                                            |
+| `OCEAN__INTEGRATION__IDENTIFIER`                     | The identifier of the integration.                                                                                                                                                                                                                                   |
+| `OCEAN__INTEGRATION__TYPE`                           | should be set to `aws`.                                                                                                                                                                                                                                              |
+
 </details>
 
 ## Manual installation (on-premise)
@@ -78,19 +102,20 @@ In order to successfully deploy the AWS integration, it's crucial to ensure that
 <details>
 <summary>Environment Variables</summary>
 
-| Variable | Description |
-| --- | --- |
-| `OCEAN__PORT__CLIENT_ID` | [The client ID of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API). |
-| `OCEAN__PORT__CLIENT_SECRET` | [The client secret of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API). |
-| `OCEAN__PORT__BASE_URL`                     | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US |
-| `OCEAN__INTEGRATION__CONFIG__AWS_ACCESS_KEY_ID` | [The AWS Access Key ID of the IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html). |
-| `OCEAN__INTEGRATION__CONFIG__AWS_SECRET_ACCESS_KEY` | [The AWS Secret Access Key of the IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html). |
-| `OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY` | (Optional) AWS API Key for custom events, used to validate the event source for real-time event updates. |
-| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ROLE_ARN` | [(Optional) AWS Organization Role ARN, in case the account the integration is installed on is not the root account, used to read organization accounts for multi-account access](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html). |
-| `OCEAN__INTEGRATION__CONFIG__ACCOUNT_READ_ROLE_NAME` | [(Optional) AWS Account Read Role Name, the role name used to read the account in which the integration is not installed on, used for multi-account access.](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html). |
-| `OCEAN__EVENT_LISTENER` | [The event listener object](https://ocean.getport.io/framework/features/event-listener/). |
-| `OCEAN__INTEGRATION__IDENTIFIER` | The identifier of the integration. |
-| `OCEAN__INTEGRATION__TYPE` | should be set to `aws`. |
+| Variable                                             | Description                                                                                                                                                                                                                                                          |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OCEAN__PORT__CLIENT_ID`                             | [The client ID of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API).                                                                                                                                    |
+| `OCEAN__PORT__CLIENT_SECRET`                         | [The client secret of the Port integration](https://docs.getport.io/configuration-methods/#:~:text=To%20get%20your%20Port%20API,API).                                                                                                                                |
+| `OCEAN__PORT__BASE_URL`                              | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US                                                                                                                                                                              |
+| `OCEAN__INTEGRATION__CONFIG__AWS_ACCESS_KEY_ID`      | [The AWS Access Key ID of the IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html).                                                                                                                                                      |
+| `OCEAN__INTEGRATION__CONFIG__AWS_SECRET_ACCESS_KEY`  | [The AWS Secret Access Key of the IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html).                                                                                                                                                  |
+| `OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY`    | (Optional) AWS API Key for custom events, used to validate the event source for real-time event updates.                                                                                                                                                             |
+| `OCEAN__INTEGRATION__CONFIG__ORGANIZATION_ROLE_ARN`  | [(Optional) AWS Organization Role ARN, in case the account the integration is installed on is not the root account, used to read organization accounts for multi-account access](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html). |
+| `OCEAN__INTEGRATION__CONFIG__ACCOUNT_READ_ROLE_NAME` | [(Optional) AWS Account Read Role Name, the role name used to read the account in which the integration is not installed on, used for multi-account access.](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html).                                        |
+| `OCEAN__EVENT_LISTENER`                              | [The event listener object](https://ocean.getport.io/framework/features/event-listener/).                                                                                                                                                                            |
+| `OCEAN__INTEGRATION__IDENTIFIER`                     | The identifier of the integration.                                                                                                                                                                                                                                   |
+| `OCEAN__INTEGRATION__TYPE`                           | should be set to `aws`.                                                                                                                                                                                                                                              |
+
 </details>
 
 ## Further Examples


### PR DESCRIPTION
# Description

- **Add `useGetResourceAPI` option to the AWS Lambda function mapping in the `mapping_extra_resources.md`.**
- **feat: add helm installation**
- **feat: add installation warnings**


## Updated docs pages

- AWS Installation (/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installation)
- Mapping extra resources (/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources)
