### PR TITLE
fixed broken cloudformation guide url in IaC guide

### DIFF
--- a/docs/guides-and-tutorials/create-cloud-resource-using-iac.md
+++ b/docs/guides-and-tutorials/create-cloud-resource-using-iac.md
@@ -769,6 +769,5 @@ With Port, platform engineers can design precise and flexible self-service actio
 
 More relevant guides and examples:
 
-- [Deploy AWS resources using AWS CloudFormation
-  ](https://docs.getport.io/actions-and-automations/setup-backend/github-workflow/examples/deploy-cloudformation-template)
+- [Deploy AWS resources using AWS CloudFormation](https://docs.getport.io/actions-and-automations/setup-backend/github-workflow/examples/AWS/deploy-cloudformation-template)
 - [Create an S3 bucket using Self-Service Actions](https://docs.getport.io/actions-and-automations/setup-backend/webhook/examples/s3-using-webhook/)


### PR DESCRIPTION
# Description

The link at the bottom of the _Create Cloud Resource Using IAC_ page pointing to the _Deploy AWS resources using AWS CloudFormation_ guide was broken. Link has been updated to point to the correct _Deploy AWS resources using AWS CloudFormation_ page. 

## Added docs pages

N/A

## Updated docs pages

/docs/guides-and-tutorials/create-cloud-resource-using-iac.md
