### PR TITLE
Add multi account permissions

### DIFF
--- a/docs/actions-and-automations/setup-backend/github-workflow/examples/AWS/deploy-s3-bucket-crossplane.md
+++ b/docs/actions-and-automations/setup-backend/github-workflow/examples/AWS/deploy-s3-bucket-crossplane.md
@@ -478,5 +478,5 @@ In this example we did not create the Port entity for the S3 bucket.
 
 - You can [Connect Port's AWS exporter](/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/aws.md)
   to make sure all of the properties and entities are automatically ingested from AWS.
-  - You can learn how to setup Port's AWS exporter [here](/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installation.md).
+  - You can learn how to setup Port's AWS exporter [here](/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/installation.md).
   - You can see example configurations and use cases [here](/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/examples.md).

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/aws.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/aws.md
@@ -187,4 +187,4 @@ These permissions are essential for the proper functioning of the integration wi
 
 ## Getting started
 
-Continue to the [installation](./installation.md) guide to learn how to install the AWS integration.
+Continue to the [installation](./installations/installation.md) guide to learn how to install the AWS integration.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/aws.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/aws.md
@@ -34,6 +34,8 @@ Easily fill your software catalog with data directly from your AWS Organization,
 
 To install the integration, follow the [installation](./installations/installation.md) guide.
 
+To properly configure permissions for production and to enable multiple accounts collection check out our [multiple accounts guide](./installations/multi_account.md)
+
 ## How it works
 
 Port's AWS integration can retrieve all the resources supported by the [Cloud Control API](https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/supported-resources.html), and export them to Port as entities of existing blueprints.
@@ -188,3 +190,5 @@ These permissions are essential for the proper functioning of the integration wi
 ## Getting started
 
 Continue to the [installation](./installations/installation.md) guide to learn how to install the AWS integration.
+
+To properly configure permissions for production and to enable multiple accounts collection check out our [multiple accounts guide](./installations/multi_account.md)

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/aws.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/aws.md
@@ -32,7 +32,7 @@ Easily fill your software catalog with data directly from your AWS Organization,
 
 ## Installation
 
-To install the integration, follow the [installation](./installation.md) guide.
+To install the integration, follow the [installation](./installations/installation.md) guide.
 
 ## How it works
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/_category_.json
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Installations",
+    "position": 1
+  }
+  

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/installation.md
@@ -12,6 +12,15 @@ import TabItem from "@theme/TabItem"
 - To get Port API credentials, you check out the [Port API documentation](/build-your-software-catalog/custom-integration/api/).
 - In order to successfully deploy the AWS integration, it's crucial to ensure that the user who deploys the integration in the AWS Organization has the appropriate access permissions to create all of the above resources.
 
+:::tip
+If you want to:
+
+1. Enable multiple accounts for the integration.
+2. View account data.
+
+Make sure you check out our [Multiple Accounts guide](./multi_account.md)
+:::
+
 Choose one of the following installation methods:
 <Tabs groupId="installation-platforms" queryString="installation-platforms">
 <TabItem value="helm" label="Helm">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/installation.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 0
 ---
 
 import Tabs from "@theme/Tabs"

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Multi account support

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/multi_account.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/multi_account.md
@@ -1,0 +1,140 @@
+---
+sidebar_position: 3
+---
+
+# Multi account support
+
+This guide will provide you with the necessary tools for enabling our Ocean AWS Integration to digest multiple account's data. There's a brief explaination about how AWS permissions model work, you can ignore that and continue to the practical walkthrough,
+
+## Some architectural overview
+
+### (Very) Brief to AWS's permissions model
+
+### Permissions we're gonna request
+
+## Walkthrough
+
+For enabling multiaccount, there's 3 main steps:
+
+1. Creating a new Role in the root account of your AWS. [here](#creating-the-root-account-role)
+2. Give this role the right permissions. [here](#adding-sufficient-permissions-to-the-role)
+3. Enabling assume role to this role to make cross-account requests.
+4. Adding multiple accounts to the policies scope.
+
+### Creating the root-account role
+
+1. Go into the root account $How do i find it?
+2. Go to `IAM->Roles`
+3. Click on the top right `Create Role` button.
+4. Pick `AWS Account` ($Does this makes sense? ). Click on `next`.
+5. Scroll to the bottom, click `Next`
+6. Name and give tags to your new role, Click on `Create Role`
+7. The new role was Created!
+
+### Adding sufficient permissions to the role
+
+1. Go to `IAM->Roles`
+2. Click on your new created role
+3. Click on `Add permissions` -> `Create inline policy`
+4. Pick the JSON policy editor
+5. Paste the following policy:
+
+    <details>
+    <summary> Root Account Policy </summary>
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AWSOrganizationsReadOnly",
+                "Effect": "Allow",
+                "Action": [
+                    "organizations:Describe*", // You can provide specific accounts here
+                    "organizations:List*" // You can provide specific accounts here
+                ],
+                "Resource": "*"
+            },
+            {
+                "Sid": "AWSOrganizationsReadOnlyAccountData",
+                "Effect": "Allow",
+                "Action": [
+                    "account:GetAlternateContact",
+                    "account:GetContactInformation",
+                    "account:ListRegions",
+                    "account:GetRegionOptStatus",
+                    "account:GetPrimaryEmail"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+    ```
+    </details>
+
+6. Click on `Next`
+7. Give it a meaningful name, `Create policy`
+
+### Enabling AssumeRole to this role
+
+#### Add permissions from the root account
+
+1. Go to your root-account's newly created Role
+2. Click on `Trust Relationships` $Screenshot here
+3. Click on `Edit trust policy`, paste the following trust policy (Make sure to replace the `<non_root_account>` to your integration's non root account ID):
+
+    <details>
+    <summary> Root Account Trust Policy </summary>
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn:aws:iam::<non_root_account>:root/<accountReadRoleName>"
+                },
+                "Action": "sts:AssumeRole",
+                "Condition": {}
+            }
+        ]
+    }
+    ```
+    </details>
+
+4. Click on `Update policy`
+5. Done!
+
+#### Adding permissions from the integration's account
+
+1. Switch to your non-root account.
+2. Click on the Role created for the integration (either by you or by our terraform module)
+3. On the `Trust Relationships` tab, make sure that you have the following policy:
+
+    <details>
+    <summary> Root Account Trust Policy </summary>
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn:aws:iam::<non_root_account>:root/<organizationRoleArn>"
+                },
+                "Action": "sts:AssumeRole",
+                "Condition": {}
+            }
+        ]
+    }
+    ```
+    </details>
+
+4. Done!
+
+### Creating the root-account role
+
+In order to keep adding accounts to the integration's scope, permissions must be delivered for and from each of the accounts.
+For each account you want to have, you should make sure the following applies:
+
+1. In your root-account, The additional account must in the scope of the trust policy
+2. In your non-root account, The 


### PR DESCRIPTION
# Description

Added a documentation for enabling multi account support.

## Added docs pages

Please also include the path for the added docs

- Multi accounts in AWS (`/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/multi-accounts`)
