### PR TITLE
Add Terraform Import State guide

### DIFF
--- a/docs/build-your-software-catalog/custom-integration/iac/terraform/examples/import-and-manage-integration.md
+++ b/docs/build-your-software-catalog/custom-integration/iac/terraform/examples/import-and-manage-integration.md
@@ -1,0 +1,270 @@
+---
+sidebar_position: 3
+title: Import and Manage an Integration
+description: Manage an integrations mappings using Terraform
+---
+
+import FindCredentials from "/docs/build-your-software-catalog/custom-integration/api/\_template_docs/\_find_credentials_collapsed.mdx";
+import PortApiRegionTip from "/docs/generalTemplates/_port_region_parameter_explanation_template.md"
+import Tabs from "@theme/Tabs"
+import TabItem from "@theme/TabItem"
+
+
+# Manage integration mapping using Terraform
+
+In this example we'll use the Import State feature of Terraform, then manage our Port integration's mapping with Terraform.
+
+
+## Prerequisites
+
+You will need to create an integration within the Port UI, For example the [Kubernetes Exporter](../../../../../guides-and-tutorials/visualize-service-k8s-runtime)
+
+:::note  Installation Id
+As you create the integration, take note of the installation Id.
+:::
+
+
+### Getting started
+
+In order to interact with the API you will need an API token.
+
+Getting an API token involves 2 steps:
+
+1. Finding your Port API credentials.
+2. Making an API request to generate a valid token.
+
+### Find your Port credentials
+
+<FindCredentials />
+
+### Download your integration configuration into a file
+
+Here are some code examples showing how to download the integration configuration in various programming languages:
+
+<Tabs groupId="code-examples" defaultValue="curl" values={[
+{label: "cURL", value: "curl"},
+{label: "Python", value: "python"},
+{label: "Javascript", value: "js"}
+]}>
+
+<TabItem value="curl">
+
+```bash showLineNumbers
+#/usr/bin/env bash
+
+# Dependencies to install:
+# For apt:
+# $ sudo apt-get install jq
+# For yum:
+# $ sudo yum install jq
+
+INSTALLATION_ID="YOUR_INSTALLATION_ID"
+CLIENT_ID="YOUR_CLIENT_ID"
+CLIENT_SECRET="YOUR_CLIENT_SECRET"
+
+ACCESS_TOKEN=$(curl -s --location -X POST 'https://api.getport.io/v1/auth/access_token' \
+--header 'Content-Type: application/json' \
+--data-raw """{
+    \"clientId\": \"${CLIENT_ID}\",
+    \"clientSecret\": \"${CLIENT_SECRET}\"
+}""" | jq -r '.accessToken')
+
+curl -s -X GET \
+  "https://api.getport.io/v1/integration/${INSTALLATION_ID}?byField=installationId" \
+  -H 'accept: */*' \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  | jq '.integration.config' > ./${INSTALLATION_ID}.json
+
+```
+
+</TabItem>
+
+<TabItem value="python">
+
+```python showLineNumbers
+# Dependencies to install:
+# $ python -m pip install requests
+
+import json
+import requests
+
+CLIENT_ID = 'YOUR_CLIENT_ID'
+CLIENT_SECRET = 'YOUR_CLIENT_SECRET'
+INSTALLATION_ID = 'YOUR_INSTALLATION_ID'
+
+API_URL = 'https://api.getport.io/v1'
+
+credentials = {'clientId': CLIENT_ID, 'clientSecret': CLIENT_SECRET}
+
+token_response = requests.post(f'{API_URL}/auth/access_token', json=credentials)
+
+access_token = token_response.json()['accessToken']
+
+headers = {
+    'Authorization': f'Bearer {access_token}'
+}
+
+integration_response = requests.get(
+    f'{API_URL}/integration/{INSTALLATION_ID}?byField=installationId',
+    headers=headers)
+
+with open(f'{INSTALLATION_ID}.json', 'w') as file:
+    file.write(json.dumps(integration_response.json()['integration']['config']))
+```
+
+</TabItem>
+
+<TabItem value="js">
+
+```javascript showLineNumbers
+// Dependencies to install:
+// $ npm install axios --save
+
+
+const fs = require('node:fs/promises');
+const axios = require("axios").default;
+
+const CLIENT_ID = "YOUR_CLIENT_ID";
+const CLIENT_SECRET = "YOUR_CLIENT_SECRET";
+const INSTALLATION_ID = "YOUR_INSTALLATION_ID";
+
+const API_URL = "https://api.getport.io/v1";
+
+(async () => {
+  const response = await axios.post(`${API_URL}/auth/access_token`, {
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+  });
+
+  const accessToken = response.data.accessToken;
+  const config = {
+      headers: {
+          Authorization: `Bearer ${accessToken}`,
+      }
+  };
+
+  const integrationResponse = await axios.post(
+      `${API_URL}/v1/integration/${INSTALLATION_ID}?byField=installationId`, 
+      config)
+
+  await fs.writeFile(
+    `./${INSTALLATION_ID}.json`, 
+    JSON.stringify(integrationResponse.data.integration.config)
+  )
+})();
+```
+
+</TabItem>
+
+</Tabs>
+
+<PortApiRegionTip/>
+
+Here is the complete `main.tf` file:
+
+:::note `main.tf` dependency
+Notice that the `main.tf` file references the downloaded file generated in the previous command
+
+See the `file("${path.module}/...")` function
+:::
+
+<details>
+<summary>Complete Terraform definition file</summary>
+
+```hcl showLineNumbers
+terraform {
+  required_providers {
+    port = {
+      source  = "port-labs/port-labs"
+      version = "~> 2.0.3"
+    }
+  }
+
+  provider "port" {
+  client_id = "YOUR_CLIENT_ID"     # or set the environment variable PORT_CLIENT_ID
+  secret    = "YOUR_CLIENT_SECRET" # or set the environment variable PORT_CLIENT_SECRET
+  base_url  = "https://api.getport.io"
+}
+
+resource "port_integration" "tf_{my-installation-id}" {
+  installation_id       = "{my-installation-id}"
+  installation_app_type = "{my-installation-type}"
+  title                 = "{my-installation-title}"
+  version               = ""
+  # The reason for the jsonencode|jsondecode is
+  # to preserve the exact syntax as terraform expects,
+  # this resolves conflicts in the state caused by indents
+  config                = jsonencode(jsondecode(file("${path.module}/{my-installation-id}.json")))
+}
+
+```
+
+<PortApiRegionTip/>
+
+</details>
+
+Let's break down the definition file and understand the different parts:
+
+## Module imports
+
+This part includes importing and setting up the required Terraform providers and modules:
+
+```hcl showLineNumbers
+terraform {
+  required_providers {
+    port = {
+      source  = "port-labs/port-labs"
+      version = "~> 2.0.3"
+    }
+  }
+}
+
+provider "port" {
+  client_id = "YOUR_CLIENT_ID"     # or set the environment variable PORT_CLIENT_ID
+  secret    = "YOUR_CLIENT_SECRET" # or set the environment variable PORT_CLIENT_SECRET
+  base_url  = "https://api.getport.io"
+}
+```
+
+<PortApiRegionTip/>
+
+## Port Terraform Provider Integration Resource
+
+This part includes declaring the Port integration and pointing the downloaded json file as the source of the integration configuration
+
+```hcl showLineNumbers
+resource "port_integration" "tf_{my-installation-id}" {
+  installation_id       = "{my-installation-id}"
+  installation_app_type = "{my-installation-type}"
+  title                 = "{my-installation-title}"
+  version               = ""
+  # The reason for the jsonencode|jsondecode is
+  # to preserve the exact syntax as terraform expects,
+  # this resolves conflicts in the state caused by indents
+  config                = jsonencode(jsondecode(file("${path.module}/{my-installation-id}.json")))
+}
+
+```
+
+:::note Terraform JSON formatting
+Since Terraform is very explicit when writing and reading the state, we use `jsonencode` and `jsondecode` on the raw JSON file to make sure we do not have a conflict simply by having a bit different formatting than the Terraform JSON formatting.
+:::
+
+To use this example yourself, simply replace the placeholders for `installation_id`, `client_id` and `secret` and then run the following commands to setup terraform, import the state and verifying that everything was imported:
+
+```shell showLineNumbers
+# install modules and create an initial state
+terraform init
+# import state from the Port API
+terraform import port_integration.tf_{my-installation-id} {my-installation-id}
+# To view Terraform's planned changes based on your .tf definition file:
+terraform plan
+```
+
+
+
+
+## Result
+
+After running `terraform plan` you should see that there are not changes from the imported state.
+

--- a/docs/build-your-software-catalog/custom-integration/iac/terraform/terraform.md
+++ b/docs/build-your-software-catalog/custom-integration/iac/terraform/terraform.md
@@ -476,6 +476,12 @@ terraform import port_entity.myEntity "{blueprintIdentifier}:{entityIdentifier}"
 Before using `terraform import` to bring data from your Port account into your Terraform state file, make sure your resource definitions match the schema of your resources in Port. If they don't, your state will be deleted in the next `terraform apply`, since Terraform will try to apply the empty resources and override the imported state, while also updating Port in the process.                                                                                                                                          
 :::
 
+:::note Advanced Example
+See [this](./examples/import-and-manage-integration) guide which explains more in depth of how you can use import state to manage Port integrations using Terraform
+
+
+:::
+
 ## Examples
 
 Refer to the [examples](./examples/examples.md) page for practical configurations and their corresponding blueprint definitions.


### PR DESCRIPTION
# Description

Add a guide for managing an integration using Terraform, including how to import the state from an existing integration.

## Added docs pages

- Import and Manage an Integration (`/build-your-software-catalog/custom-integration/iac/terraform/examples/import-and-manage-integration`)

## Updated docs pages

- Terraform (`/build-your-software-catalog/custom-integration/iac/terraform/terraform.md`) (added link to new guide above)
