### PR TITLE
[Datadog] - update docs to reflect changes in integration

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog.md
@@ -863,7 +863,7 @@ resources:
               unique | map(split(":")[1])
 ```
 :::tip Service Relation
-Based on the [best practices for tagging infrastructure](https://www.datadoghq.com/blog/tagging-best-practices/), the default JQ maps SLOs to services using tags that starts with the `service` keyword
+Based on the [best practices for tagging infrastructure](https://www.datadoghq.com/blog/tagging-best-practices/), the default mapping connects SLOs to services using tags that starts with the `service` keyword.
 :::
 </details>
 


### PR DESCRIPTION
# Description

We recently made some changes to the integration blueprint to match the correct data types. We also added a new kind for SLO history. These changes are applied here in the docs as well


## Updated docs pages

docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog.md