### PR TITLE
fixed indenting in LD helm command

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly/launchdarkly.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly/launchdarkly.md
@@ -72,16 +72,16 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install launchdarkly port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true \
-	--set integration.identifier="my-launchdarkly-integration"  \
-	--set integration.type="launchdarkly"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.secrets.launchdarklyHost="string" \
-	--set integration.secrets.launchdarklyToken="string" \
+  --set integration.identifier="my-launchdarkly-integration"  \
+  --set integration.type="launchdarkly"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.secrets.launchdarklyHost="string" \
+  --set integration.secrets.launchdarklyToken="string" \
 ```
 
 <PortApiRegionTip/>

--- a/docs/guides-and-tutorials/let-developers-enrich-services-using-gitops.md
+++ b/docs/guides-and-tutorials/let-developers-enrich-services-using-gitops.md
@@ -195,11 +195,11 @@ Fill out the form with your values:
   {
     "port_context": {
       "entity": "{{ .entity.identifier }}",
-      "runId": "{{ .run.id }}",
+      "runId": "{{ .run.id }}"
     },
     "domain": "{{ .inputs.domain }}",
     "type": "{{ .inputs.type }}",
-    "lifecycle": "{{ .inputs.lifecycle }}",
+    "lifecycle": "{{ .inputs.lifecycle }}"
   }
   ```
 </TabItem>
@@ -232,11 +232,11 @@ In order to protect the webhook, see the [Validating webhook signatures page](..
   {
     "port_context": {
       "entity": "{{ .entity.identifier }}",
-      "runId": "{{ .run.id }}",
+      "runId": "{{ .run.id }}"
     },
     "domain": "{{ .inputs.domain }}",
     "type": "{{ .inputs.type }}",
-    "lifecycle": "{{ .inputs.lifecycle }}",
+    "lifecycle": "{{ .inputs.lifecycle }}"
   }
   ```
 
@@ -270,11 +270,11 @@ Then, fill out your workflow details:
     "port_context": {
       "entity": "{{ .entity.identifier }}",
       "repo_url": "{{ .entity.properties.url }}",
-      "runId": "{{ .run.id }}",
+      "runId": "{{ .run.id }}"
     },
     "domain": "{{ .inputs.domain }}",
     "type": "{{ .inputs.type }}",
-    "lifecycle": "{{ .inputs.lifecycle }}",
+    "lifecycle": "{{ .inputs.lifecycle }}"
   }
   ```
 


### PR DESCRIPTION
# Description

LaunchDarkly helm command had a weird indenting issue, and enrich service guide had trailing commas.
![Screenshot 2024-07-15 at 10 45 39 AM](https://github.com/user-attachments/assets/08d819e6-af2d-4645-930f-9d71231a57c4)

## Updated docs pages

- docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly/launchdarkly.md
- docs/guides-and-tutorials/let-developers-enrich-services-using-gitops.md