### PR TITLE
Fix typos in AWS multi_account.md document

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
@@ -63,7 +63,7 @@ The integration expects the non-root account's role the be named the same (`acco
 1. Name of a role in the integration's account giving it the following Policies: (This was created for you if you ran our terraform module)
    1. `arn:aws:iam::aws:policy/ReadOnlyAccess`
    2. Custom policy with `account:ListRegions` permissions
-   3. `sts:AssumeRole` on `arn:aws:iam::<root_account>:root/<organizationRoleArn>`
+   3. `sts:AssumeRole` on `arn:aws:iam::<root_account>:role/<organizationRoleArn>`
 
 :::tip
 You can create the custom policy using the following json:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
@@ -87,7 +87,7 @@ You can create the custom policy using the following json:
 :::
 
 :::tip
-The name of this role (not the ARN) is refernced as `accountReadRoleName` in this doc.
+The name of this role (not the ARN) is referenced as `accountReadRoleName` in this doc.
 :::
 
 ## Walkthrough

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
@@ -8,7 +8,7 @@ This guide will provide you with the necessary tools for enabling our Ocean AWS 
 
 ## Our Permissions model
 
-A few key conecpts in the AWS's permissions model:
+A few key concepts in the AWS's permissions model:
 
 1. *Policy*: A document that defines permissions, specifying what actions are allowed or denied for particular resources and under what conditions.
 2. *Role*: An identity with specific permissions and trust policies.


### PR DESCRIPTION
# Description

Looking through AWS multi account support guide, I noticed a few typos/mistakes, this PR aims to fix them.

- https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account

## Updated docs pages

Please also include the path for the updated docs

- Multi Account (`/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/multi_account.md`)
