### PR TITLE
fixed helm indentation and a few other things

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog.md
@@ -57,17 +57,17 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-datadog-integration port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
-	--set scheduledResyncInterval=60 \
-	--set integration.identifier="my-datadog-integration"  \
-	--set integration.type="datadog"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.config.datadogBaseUrl="https://api.datadoghq.com"  \
-	--set integration.secrets.datadogApiKey="<your-datadog-api-key>"  \
-	--set integration.secrets.datadogApplicationKey="<your-datadog-application-key>" 
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
+  --set scheduledResyncInterval=60 \
+  --set integration.identifier="my-datadog-integration"  \
+  --set integration.type="datadog"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.config.datadogBaseUrl="https://api.datadoghq.com"  \
+  --set integration.secrets.datadogApiKey="<your-datadog-api-key>"  \
+  --set integration.secrets.datadogApplicationKey="<your-datadog-application-key>" 
 ```
 
 <PortApiRegionTip/>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/dynatrace.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/dynatrace.md
@@ -57,7 +57,7 @@ helm upgrade --install my-dynatrace-integration port-labs/port-ocean \
   --set integration.type="dynatrace"  \
   --set integration.eventListener.type="POLLING"  \
   --set integration.secrets.dynatraceApiKey="<your-api-key>"  \
-  --set integration.config.dynatraceHostUrl="<your-isntance-url>"
+  --set integration.config.dynatraceHostUrl="<your-instance-url>"
 ```
 
 <PortApiRegionTip/>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
@@ -68,16 +68,16 @@ If you are using New Relic's EU region, add the following flag to the command:
 
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-newrelic-integration port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
-	--set scheduledResyncInterval=120 \
-	--set integration.identifier="my-newrelic-integration"  \
-	--set integration.type="newrelic"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.secrets.newRelicAPIKey="<NR_API_KEY>"  \
-	--set integration.secrets.newRelicAccountID="<NR_ACCOUNT_ID>"
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
+  --set scheduledResyncInterval=120 \
+  --set integration.identifier="my-newrelic-integration"  \
+  --set integration.type="newrelic"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.secrets.newRelicAPIKey="<NR_API_KEY>"  \
+  --set integration.secrets.newRelicAccountID="<NR_ACCOUNT_ID>"
 ```
 
 <PortApiRegionTip/>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/sentry.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/sentry.md
@@ -65,16 +65,16 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-sentry-integration port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
-	--set integration.identifier="my-sentry-integration"  \
-	--set integration.type="sentry"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.config.sentryHost="https://sentry.io"  \
-	--set integration.secrets.sentryToken="string"  \
-	--set integration.config.sentryOrganization="string"
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
+  --set integration.identifier="my-sentry-integration"  \
+  --set integration.type="sentry"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.config.sentryHost="https://sentry.io"  \
+  --set integration.secrets.sentryToken="string"  \
+  --set integration.config.sentryOrganization="string"
 ```
 <PortApiRegionTip/>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-cost/opencost.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-cost/opencost.md
@@ -55,15 +55,15 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-opencost-integration port-labs/port-ocean \
-	--set port.clientId="CLIENT_ID"  \
-	--set port.clientSecret="CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="CLIENT_ID"  \
+  --set port.clientSecret="CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
-	--set integration.identifier="my-opencost-integration"  \
-	--set integration.type="opencost"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.config.opencostHost="https://myOpenCostInstance:9003"
+  --set integration.identifier="my-opencost-integration"  \
+  --set integration.type="opencost"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.config.opencostHost="https://myOpenCostInstance:9003"
 ```
 
 <PortApiRegionTip/>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/installation.md
@@ -42,17 +42,17 @@ You can check out the Helm chart [here](https://github.com/port-labs/helm-charts
 ```bash
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install aws port-labs/port-ocean \
---set port.clientId="$PORT_CLIENT_ID"  \
---set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
---set port.baseUrl="https://api.getport.io"  \
---set initializePortResources=true  \
---set sendRawDataExamples=true  \
---set scheduledResyncInterval=1440 \
---set integration.identifier="my-aws"  \
---set integration.type="aws"  \
---set integration.eventListener.type="POLLING"  \
---set integration.config.awsAccessKeyId="$AWS_ACCESS_KEY_ID" \
---set integration.config.awsSecretAccessKey="$AWS_SECRET_ACCESS_KEY"
+  --set port.clientId="$PORT_CLIENT_ID"  \
+  --set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
+  --set sendRawDataExamples=true  \
+  --set scheduledResyncInterval=1440 \
+  --set integration.identifier="my-aws"  \
+  --set integration.type="aws"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.config.awsAccessKeyId="$AWS_ACCESS_KEY_ID" \
+  --set integration.config.awsSecretAccessKey="$AWS_SECRET_ACCESS_KEY"
 ```
 
 ### IRSA
@@ -70,16 +70,16 @@ You'll need to:
 ```bash
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install aws port-labs/port-ocean \
---set port.clientId="$PORT_CLIENT_ID"  \
---set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
---set port.baseUrl="https://api.getport.io"  \
---set initializePortResources=true  \
---set sendRawDataExamples=true  \
---set scheduledResyncInterval=1440 \
---set integration.identifier="my-aws"  \
---set integration.type="aws"  \
---set integration.eventListener.type="POLLING"  \
---set podServiceAccount.name="$SERVICE_ACCOUNT"
+  --set port.clientId="$PORT_CLIENT_ID"  \
+  --set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
+  --set sendRawDataExamples=true  \
+  --set scheduledResyncInterval=1440 \
+  --set integration.identifier="my-aws"  \
+  --set integration.type="aws"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set podServiceAccount.name="$SERVICE_ACCOUNT"
 ```
 
 ### Multiple account support
@@ -95,18 +95,18 @@ Then, you'll be able to run the integration: (You can switch the `podServiceAcco
 ```bash
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install aws port-labs/port-ocean \
---set port.clientId="$PORT_CLIENT_ID"  \
---set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
---set port.baseUrl="https://api.getport.io"  \
---set initializePortResources=true  \
---set sendRawDataExamples=true  \
---set scheduledResyncInterval=1440 \
---set integration.identifier="my-aws"  \
---set integration.type="aws"  \
---set integration.eventListener.type="POLLING"  \
---set podServiceAccount.name="$SERVICE_ACCOUNT"  \ 
---set integration.config.accountReadRoleName="$YOUR_ACCOUNT_READ_ROLE_NAME"  \ 
---set integration.config.organizationRoleArn="$YOUR_ORGANIZATION_ROLE_ARN"
+  --set port.clientId="$PORT_CLIENT_ID"  \
+  --set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
+  --set sendRawDataExamples=true  \
+  --set scheduledResyncInterval=1440 \
+  --set integration.identifier="my-aws"  \
+  --set integration.type="aws"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set podServiceAccount.name="$SERVICE_ACCOUNT"  \ 
+  --set integration.config.accountReadRoleName="$YOUR_ACCOUNT_READ_ROLE_NAME"  \ 
+  --set integration.config.organizationRoleArn="$YOUR_ORGANIZATION_ROLE_ARN"
 ```
 
   </TabItem>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation.md
@@ -50,18 +50,18 @@ You should have the following information ready:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install azure port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
-  	--set sendRawDataExamples=true  \
-	--set scheduledResyncInterval=1440 \
-	--set integration.identifier="azure"  \
-	--set integration.type="azure"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.config.azureClientId="<AZURE_CLIENT_ID>"  \
-	--set integration.config.azureClientSecret="<AZURE_CLIENT_SECRET>" \
-	--set integration.config.azureTenantId="<AZURE_TENANT_ID>"
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
+  --set sendRawDataExamples=true  \
+  --set scheduledResyncInterval=1440 \
+  --set integration.identifier="azure"  \
+  --set integration.type="azure"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.config.azureClientId="<AZURE_CLIENT_ID>"  \
+  --set integration.config.azureClientSecret="<AZURE_CLIENT_SECRET>" \
+  --set integration.config.azureTenantId="<AZURE_TENANT_ID>"
 ```
 
 <PortApiRegionTip/>
@@ -351,9 +351,9 @@ the Azure subscription has the appropriate access permissions. One of the follow
 	<img src='/img/integrations/azure-exporter/DevPortalIngestCloudProvider.png' width='70%' border='1px' /> <br/><br/>
 
 3. Edit and copy the installation command.
-	 :::tip Installation Command
-	 The installation command includes placeholders that allow you to customize the integration's configuration. For
-	 example, you can update the command and specify the `event_grid_system_topic_name` parameter if you already have one.
+	:::tip Installation Command
+	The installation command includes placeholders that allow you to customize the integration's configuration. For
+	example, you can update the command and specify the `event_grid_system_topic_name` parameter if you already have one.
 
 	- Specify the `event_grid_system_topic_name` parameter if you already have an Event Grid system topic of
 		type `Microsoft.Resources.Subscriptions` in your subscription;

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/project/_project.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/examples/project/_project.mdx
@@ -13,7 +13,7 @@
     "mirrorProperties": {},
     "calculationProperties": {},
     "aggregationProperties": {}
-},
+}
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/installation.md
@@ -44,16 +44,16 @@ The Ocean integration doesn't store the encoded file anywhere but locally. It's 
    ```bash
    helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
    helm upgrade --install gcp port-labs/port-ocean \
-   --set port.clientId="$PORT_CLIENT_ID"  \
-   --set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
-   --set port.baseUrl="https://api.getport.io"  \
-   --set initializePortResources=true  \
-   --set sendRawDataExamples=true  \
-   --set scheduledResyncInterval=1440 \
-   --set integration.identifier="ocean-gcp-integration"  \
-   --set integration.type="gcp"  \
-   --set integration.eventListener.type="POLLING"  \
-   --set integration.config.encodedADCConfiguration="<paste_the_encoded_file_content_here>"
+     --set port.clientId="$PORT_CLIENT_ID"  \
+     --set port.clientSecret="$PORT_CLIENT_SECRET_ID"  \
+     --set port.baseUrl="https://api.getport.io"  \
+     --set initializePortResources=true  \
+     --set sendRawDataExamples=true  \
+     --set scheduledResyncInterval=1440 \
+     --set integration.identifier="ocean-gcp-integration"  \
+     --set integration.type="gcp"  \
+     --set integration.eventListener.type="POLLING"  \
+     --set integration.config.encodedADCConfiguration="<paste_the_encoded_file_content_here>"
    ```
 
 ## Optional- Scale permissions for a Service account

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
@@ -74,16 +74,16 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-snyk-integration port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
-	--set scheduledResyncInterval=120 \
-	--set integration.identifier="my-snyk-integration"  \
-	--set integration.type="snyk"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.secrets.token="SNYK_TOKEN"
+  --set scheduledResyncInterval=120 \
+  --set integration.identifier="my-snyk-integration"  \
+  --set integration.type="snyk"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.secrets.token="SNYK_TOKEN"
 ```
 <PortApiRegionTip/>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz.md
@@ -126,19 +126,19 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-wiz-integration port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
-	--set scheduledResyncInterval=120 \
-	--set integration.identifier="my-wiz-integration"  \
-	--set integration.type="wiz"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.secrets.wizClientId="WIZ_CLIENT_ID"  \
-	--set integration.secrets.wizClientSecret="WIZ_CLIENT_SECRET" \
-	--set integration.secrets.wizApiUrl="WIZ_API_URL"  \
-	--set integration.config.wizTokenUrl="WIZ_TOKEN_URL"  
+  --set scheduledResyncInterval=120 \
+  --set integration.identifier="my-wiz-integration"  \
+  --set integration.type="wiz"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.secrets.wizClientId="WIZ_CLIENT_ID"  \
+  --set integration.secrets.wizClientSecret="WIZ_CLIENT_SECRET" \
+  --set integration.secrets.wizApiUrl="WIZ_API_URL"  \
+  --set integration.config.wizTokenUrl="WIZ_TOKEN_URL"  
 ```
 <PortApiRegionTip/>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/event-processing/kafka.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/event-processing/kafka.md
@@ -54,16 +54,16 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install kafka port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
-	--set scheduledResyncInterval=60  \
-	--set integration.identifier="my-kafka-integration"  \
-	--set integration.type="kafka"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set-json integration.secrets.clusterConfMapping='{"local": {"bootstrap.servers": "localhost:9092"}}'
+  --set scheduledResyncInterval=60  \
+  --set integration.identifier="my-kafka-integration"  \
+  --set integration.type="kafka"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set-json integration.secrets.clusterConfMapping='{"local": {"bootstrap.servers": "localhost:9092"}}'
 ```
 
 <PortApiRegionTip/>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly/launchdarkly.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly/launchdarkly.md
@@ -72,16 +72,16 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install launchdarkly port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true \
-	--set integration.identifier="my-launchdarkly-integration"  \
-	--set integration.type="launchdarkly"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.secrets.launchdarklyHost="string" \
-	--set integration.secrets.launchdarklyToken="string" \
+  --set integration.identifier="my-launchdarkly-integration"  \
+  --set integration.type="launchdarkly"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.secrets.launchdarklyHost="string" \
+  --set integration.secrets.launchdarklyToken="string" \
 ```
 
 <PortApiRegionTip/>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
@@ -235,16 +235,16 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-gitlab-integration port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true \
-	--set scheduledResyncInterval=120 \
-	--set integration.identifier="my-gitlab-integration"  \
-	--set integration.type="gitlab"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.secrets.tokenMapping="\{\"TOKEN\": [\"GROUP_NAME/**\"]\}"
+  --set scheduledResyncInterval=120 \
+  --set integration.identifier="my-gitlab-integration"  \
+  --set integration.type="gitlab"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.secrets.tokenMapping="\{\"TOKEN\": [\"GROUP_NAME/**\"]\}"
 ```
 
 <PortApiRegionTip/>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/firehydrant.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/firehydrant.md
@@ -61,16 +61,16 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-firehydrant-integration port-labs/port-ocean \
-	--set port.clientId="CLIENT_ID"  \
-	--set port.clientSecret="CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="CLIENT_ID"  \
+  --set port.clientSecret="CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
-	--set integration.identifier="my-firehydrant-integration"  \
-	--set integration.type="firehydrant"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.config.apiUrl="https://api.firehydrant.io"  \
-	--set integration.secrets.token="<FIREHYDRANT_API_TOKEN>"
+  --set integration.identifier="my-firehydrant-integration"  \
+  --set integration.type="firehydrant"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.config.apiUrl="https://api.firehydrant.io"  \
+  --set integration.secrets.token="<FIREHYDRANT_API_TOKEN>"
 ```
 
 <PortApiRegionTip/>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/opsgenie.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/opsgenie.md
@@ -63,7 +63,7 @@ helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-opsgenie-integration port-labs/port-ocean \
   --set port.clientId="CLIENT_ID"  \
   --set port.clientSecret="CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
+  --set port.baseUrl="https://api.getport.io"  \
   --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
   --set integration.identifier="my-opsgenie-integration"  \

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/servicenow.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/servicenow.md
@@ -62,17 +62,17 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-servicenow-integration port-labs/port-ocean \
-	--set port.clientId="CLIENT_ID"  \
-	--set port.clientSecret="CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="CLIENT_ID"  \
+  --set port.clientSecret="CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
-	--set integration.identifier="my-servicenow-integration"  \
-	--set integration.type="servicenow"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.config.servicenowUsername="<SERVICENOW_USERNAME>"  \
-	--set integration.secrets.servicenowPassword="<SERVICENOW_PASSWORD>"  \
-	--set integration.config.servicenowUrl="<SERVICENOW_URL>"
+  --set integration.identifier="my-servicenow-integration"  \
+  --set integration.type="servicenow"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.config.servicenowUsername="<SERVICENOW_USERNAME>"  \
+  --set integration.secrets.servicenowPassword="<SERVICENOW_PASSWORD>"  \
+  --set integration.config.servicenowUrl="<SERVICENOW_URL>"
 ```
 <PortApiRegionTip/>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/statuspage.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/statuspage.md
@@ -59,14 +59,14 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-statuspage-integration port-labs/port-ocean \
-	--set port.clientId="CLIENT_ID"  \
-	--set port.clientSecret="CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
-	--set integration.identifier="my-statuspage-integration"  \
-	--set integration.type="statuspage"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.secrets.statuspageApiKey="<STATUSPAGE_API_KEY>"
+  --set port.clientId="CLIENT_ID"  \
+  --set port.clientSecret="CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
+  --set integration.identifier="my-statuspage-integration"  \
+  --set integration.type="statuspage"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.secrets.statuspageApiKey="<STATUSPAGE_API_KEY>"
 ```
 <PortApiRegionTip/>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/jenkins/jenkins.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/jenkins/jenkins.md
@@ -80,18 +80,18 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-jenkins-integration port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
-	--set scheduledResyncInterval=120 \
-	--set integration.identifier="my-jenkins-integration"  \
-	--set integration.type="jenkins"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.secrets.jenkinsUser="JENKINS_USER"  \
-	--set integration.secrets.jenkinsToken="JENKINS_TOKEN" \
-	--set integration.config.jenkinsHost="JENKINS_HOST"  
+  --set scheduledResyncInterval=120 \
+  --set integration.identifier="my-jenkins-integration"  \
+  --set integration.type="jenkins"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.secrets.jenkinsUser="JENKINS_USER"  \
+  --set integration.secrets.jenkinsToken="JENKINS_TOKEN" \
+  --set integration.config.jenkinsHost="JENKINS_HOST"  
 ```
 <PortApiRegionTip/>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/jira.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/jira.md
@@ -66,18 +66,18 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-jira-integration port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
-	--set scheduledResyncInterval=120 \
-	--set integration.identifier="my-jira-integration"  \
-	--set integration.type="jira"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.config.jiraHost="string"  \
-	--set integration.secrets.atlassianUserEmail="string"  \
-	--set integration.secrets.atlassianUserToken="string"
+  --set scheduledResyncInterval=120 \
+  --set integration.identifier="my-jira-integration"  \
+  --set integration.type="jira"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.config.jiraHost="string"  \
+  --set integration.secrets.atlassianUserEmail="string"  \
+  --set integration.secrets.atlassianUserToken="string"
 ```
 
 <PortApiRegionTip/>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/project-management/linear/linear.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/project-management/linear/linear.md
@@ -56,16 +56,16 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install my-linear-integration port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
-	--set scheduledResyncInterval=120 \
-	--set integration.identifier="my-linear-integration"  \
-	--set integration.type="linear"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.secrets.linearApiKey="string"
+  --set scheduledResyncInterval=120 \
+  --set integration.identifier="my-linear-integration"  \
+  --set integration.type="linear"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.secrets.linearApiKey="string"
 ```
 
 <PortApiRegionTip/>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/terraform-cloud/terraform-cloud.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/terraform-cloud/terraform-cloud.md
@@ -79,16 +79,16 @@ To install the integration using Helm, run the following command:
 ```bash showLineNumbers
 helm repo add --force-update port-labs https://port-labs.github.io/helm-charts
 helm upgrade --install terraform port-labs/port-ocean \
-	--set port.clientId="PORT_CLIENT_ID"  \
-	--set port.clientSecret="PORT_CLIENT_SECRET"  \
-	--set port.baseUrl="https://api.getport.io"  \
-	--set initializePortResources=true  \
+  --set port.clientId="PORT_CLIENT_ID"  \
+  --set port.clientSecret="PORT_CLIENT_SECRET"  \
+  --set port.baseUrl="https://api.getport.io"  \
+  --set initializePortResources=true  \
   --set sendRawDataExamples=true  \
-	--set integration.identifier="my-terraform-cloud-integration"  \
-	--set integration.type="terraform-cloud"  \
-	--set integration.eventListener.type="POLLING"  \
-	--set integration.secrets.terraformCloudHost="string" \
-	--set integration.secrets.terraformCloudToken="string" 
+  --set integration.identifier="my-terraform-cloud-integration"  \
+  --set integration.type="terraform-cloud"  \
+  --set integration.eventListener.type="POLLING"  \
+  --set integration.secrets.terraformCloudHost="string" \
+  --set integration.secrets.terraformCloudToken="string" 
 ```
 <PortApiRegionTip/>
 


### PR DESCRIPTION
# Description

I noticed that many of the helm commands in the installation examples had misaligned indentation. I believe this was due to the recent addition of `--set sendRawDataExamples=true`, so I think I fixed it everywhere.

Also fixed a visual big where `:::tip` showed instead of the green tip card (`build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation`) and fixed the spelling of "instance" (`build-your-software-catalog/sync-data-to-catalog/apm-alerting/dynatrace`)

## Updated docs pages: docs/build-your-software-catalog/sync-data-to-catalog/...
- apm-alerting/datadog.md
- apm-alerting/dynatrace.md
- apm-alerting/newrelic.md
- apm-alerting/sentry.md
- cloud-cost/opencost.md
- cloud-providers/aws/installations/installation.md
- cloud-providers/azure/installation.md
- cloud-providers/gcp/examples/project/_project.mdx
- cloud-providers/gcp/installation.md
- code-quality-security/snyk/snyk.md
- code-quality-security/wiz.md
- event-processing/kafka.md
- feature-management/launchdarkly/launchdarkly.md
- git/gitlab/installation.md
- incident-management/firehydrant.md
- incident-management/opsgenie.md
- incident-management/servicenow.md
- incident-management/statuspage.md
- jenkins/jenkins.md
- project-management/jira/jira.md
- project-management/linear/linear.md
- terraform-cloud/terraform-cloud.md