### PR TITLE
fix: hide multi_account page

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+sidebar_class_name: hidden
 ---
 
 # Multi account support


### PR DESCRIPTION
# Description

Hide multi-account installation in AWS since there is a mistake over there
 
## Added docs pages

Please also include the path for the added docs

- Multi Account Installation (`/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi-account `)
