### PR TITLE
Fix typo detremines -> determines

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/advanced.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/advanced.md
@@ -32,7 +32,7 @@ The following advanced configuration parameters are available and can be added t
 
 <Tabs groupId="config" queryString="parameter">
 <TabItem value="branch" label="branch">
-The `branch` parameter detremines the branch the integration will sync on.  
+The `branch` parameter determines the branch the integration will sync on.  
 By default this parameter is not set and the integration will sync all projects using their default branch.
 </TabItem>
 


### PR DESCRIPTION
# Description

This PR fixes a typo `detremines` to `determines`.

## Updated docs pages

- Advanced (`docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/advanced.md`)
