### PR TITLE
Remove duplicate word "token" in argocd.md

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/argocd/argocd.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/argocd/argocd.md
@@ -39,7 +39,7 @@ Set them as you wish in the script below, then copy it and run it in your termin
 | `integration.identifier`         | Change the identifier to describe your integration                                                            | ✅       |
 | `integration.type`               | The integration type                                                                                          | ✅       |
 | `integration.eventListener.type` | The event listener type                                                                                       | ✅       |
-| `integration.secrets.token`      | The ArgoCD API token token                                                                                    | ✅       |
+| `integration.secrets.token`      | The ArgoCD API token                                                                                          | ✅       |
 | `integration.config.serverUrl`   | The ArgoCD server url                                                                                         | ✅       |
 | `scheduledResyncInterval`        | The number of minutes between each resync                                                                     | ❌       |
 | `initializePortResources`        | Default true, When set to true the integration will create default blueprints and the port App config Mapping | ❌       |


### PR DESCRIPTION
# Description

This PR removes duplicate `token` word in `integration.secrets.token` property description.

## Updated docs pages

- ArgoCD (`docs/build-your-software-catalog/sync-data-to-catalog/argocd/argocd.md`)