### PR TITLE
Update set-catalog-rbac.md

### DIFF
--- a/docs/build-your-software-catalog/set-catalog-rbac/set-catalog-rbac.md
+++ b/docs/build-your-software-catalog/set-catalog-rbac/set-catalog-rbac.md
@@ -16,7 +16,7 @@ import TabItem from "@theme/TabItem";
 </center>
 <br/>
 
-Port provides granular control to ensure that every user only sees the parts of the catalog that are relevant for them.
+Port provides granular control to ensure that every user only sees the parts of the catalog that are relevant to them.
 
 Port's catalog RBAC capabilities are enabled by utilizing [permissions controls](/sso-rbac/rbac/rbac.md).
 


### PR DESCRIPTION
# Description

Made small preposition change.
Both “relevant for them” and “relevant to them” are correct, but “relevant to them” is more commonly used in this type of context.

## Updated docs pages

docs/build-your-software-catalog/set-catalog-rbac/set-catalog-rbac.md