### PR TITLE
PORT-9720 | - Fixed service blueprint BUG  for repository with teams and user mapping

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-teams/_github_export_example_repository_with_teams_relation_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-teams/_github_export_example_repository_with_teams_relation_blueprint.mdx
@@ -17,15 +17,26 @@
         "title": "Service URL",
         "type": "string",
         "format": "url"
+      },
+      "defaultBranch": {
+        "title": "Default Branch",
+        "type": "string"
       }
     },
     "required": []
   },
   "mirrorProperties": {},
   "calculationProperties": {},
+  "aggregationProperties": {},
   "relations": {
+    "admins": {
+      "title": "Admins",
+      "target": "githubUser",
+      "required": false,
+      "many": true
+    },
     "githubTeams": {
-      "title": "GitHub teams",
+      "title": "GitHub Teams",
       "target": "githubTeam",
       "required": false,
       "many": true


### PR DESCRIPTION
# Description
Fixed service blueprint error. mapping relations to undefined entites



## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- build-your-software-catalog/sync-data-to-catalog/git/github/examples/resource-mapping-examples

![image](https://github.com/user-attachments/assets/931b5a20-c7b7-436a-ac5a-948e7cd2bc2b)
![image](https://github.com/user-attachments/assets/607dda7b-8d19-494e-9068-555d97f4ddf7)
![image](https://github.com/user-attachments/assets/31985590-71a1-4d2f-9cf7-b400a8a224cc)
![image](https://github.com/user-attachments/assets/5c2a0660-0910-4302-aa4c-0328e4ae3745)

