### PR TITLE
PORT-9822|-Bug-Integrations docs use the wrong version of Terraform

### DIFF
--- a/docs/actions-and-automations/setup-backend/github-workflow/examples/Azure/tag-azure-resource.md
+++ b/docs/actions-and-automations/setup-backend/github-workflow/examples/Azure/tag-azure-resource.md
@@ -283,7 +283,7 @@ jobs:
       - name: Setup Terraform with specified version on the runner
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.9.4
+          terraform_version: 1.6.0
       
       - name: Terraform init
         id: init

--- a/docs/actions-and-automations/setup-backend/github-workflow/examples/Azure/tag-azure-resource.md
+++ b/docs/actions-and-automations/setup-backend/github-workflow/examples/Azure/tag-azure-resource.md
@@ -283,7 +283,7 @@ jobs:
       - name: Setup Terraform with specified version on the runner
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.9.4
       
       - name: Terraform init
         id: init

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/installation.md
@@ -116,7 +116,7 @@ helm upgrade --install aws port-labs/port-ocean \
 
 ## Prerequisites
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.15.0
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.9.1
 - [A logged in aws CLI 2](https://aws.amazon.com/cli/)
 - [Certificate domain name (Optional)](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-request-public.html)
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation.md
@@ -260,7 +260,7 @@ to not being able to create a new one.
 
 <h2> Prerequisites </h2>
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.15.0
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.9.1
 - [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) >= 2.26.0
 - [Permissions](#permissions)
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/_create-service-account-and-key.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/_create-service-account-and-key.mdx
@@ -35,7 +35,7 @@
 There are multiple ways to use the service account we just created. In this guide, we'll use the Service Account Key method.
 
 :::warning
-According to Google Cloud, This isn't the preffered way for Production purposes. The Terraform Installation is using Google's native method to authenticate, and is the one we propose for a Production setup.
+According to Google Cloud, This isn't the preferred way for Production purposes. The Terraform Installation is using Google's native method to authenticate, and is the one we propose for a Production setup.
 :::
 
 1. Make sure you have your selected project in the top left toggle.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/installation.md
@@ -108,7 +108,7 @@ It uses our Terraform [Ocean](https://ocean.getport.io) Integration Factory [mod
 
 ## Prerequisites
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 0.15.0
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.9.1
 - [A logged in gCloud CLI](https://cloud.google.com/sdk/gcloud) with enough [Permissions](#required-permissions-to-run-terraform-apply)
 - [Artifact Registry Image](#artifact-registry-image)
 


### PR DESCRIPTION
# Description

Updated the terraform version being referred to in the docs to a higher version

## Updated docs pages

/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation?installation-methods=terraform
/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations?installation-methods=terraform
/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/installation?installation-methods=terraform