### PR TITLE
fix: add read only permissions to the integration account

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account.md
@@ -79,6 +79,10 @@ The name of this role (not the ARN) is referenced as `integration_account` in th
 
 <details>
 <summary>Permissions</summary>
+```
+AWS::ReadOnlyAccess
+```
+
 ```json
 {
     "Version": "2012-10-17",


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

## Updated docs pages

Please also include the path for the updated docs

- AWS Multi-account (`build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/installations/multi_account`)