### PR TITLE
Clarifying Action JSON Headers

### DIFF
--- a/docs/actions-and-automations/define-automations/define-automations.md
+++ b/docs/actions-and-automations/define-automations/define-automations.md
@@ -32,7 +32,7 @@ When an event occurs in your software catalog, Port will automatically trigger t
 
 By default, automations are disabled and can be used as drafts until ready to be activated. You can enable them by setting the `publish` field to `true` in their JSON definition.
 
-## JSON structure
+## Automation JSON structure
 
 Automations are defined in JSON format. The JSON structure looks like this:
 

--- a/docs/actions-and-automations/define-automations/setup-action.md
+++ b/docs/actions-and-automations/define-automations/setup-action.md
@@ -14,6 +14,8 @@ The automation's backend is the logic that you want to execute when a trigger ev
 
 Port uses the same backend types for automations and for [self-service actions](/actions-and-automations/create-self-service-experiences/).
 
+## Backend JSON structure
+
 The backend is defined under the `invocationMethod` key in the automation's JSON structure:
 
 ```json showLineNumbers

--- a/docs/actions-and-automations/define-automations/setup-trigger.md
+++ b/docs/actions-and-automations/define-automations/setup-trigger.md
@@ -40,7 +40,7 @@ The following trigger events are available for each type:
 </TabItem>
 </Tabs>
 
-## JSON structure
+## Trigger JSON structure
 
 An automation's trigger is defined under the `trigger` key:
 


### PR DESCRIPTION
# Description

Headers in Automation docs could be clearer to avoid confusion, I've specified for each page what part of the action JSON we are talking about.

## Updated docs pages

- Define Automations (`/actions-and-automations/define-automations/`)
- Setup trigger (`/actions-and-automations/define-automations/setup-trigger`)
- Setup backend (`/actions-and-automations/define-automations/setup-action`)
