### PR TITLE
Update Github Pull Request Blueprint for Lead time in hours calculation

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_port_app_config.mdx
@@ -38,13 +38,14 @@ resources:
             prNumber: ".id"
             link: ".html_url"
             leadTimeHours: >-
-               (.created_at as $createdAt | .merged_at as $mergedAt |
-               ($createdAt | sub("\\..*Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) as $createdTimestamp |
-               ($mergedAt | if . == null then null else sub("\\..*Z$"; "Z") |
-               strptime("%Y-%m-%dT%H:%M:%SZ") | mktime end) as $mergedTimestamp |
-               if $mergedTimestamp == null then null else ($mergedTimestamp - $createdTimestamp) / 3600 end)
+                (.created_at as $createdAt | .merged_at as $mergedAt |
+                ($createdAt | sub("\\..*Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) as $createdTimestamp |
+                ($mergedAt | if . == null then null else sub("\\..*Z$"; "Z") |
+                strptime("%Y-%m-%dT%H:%M:%SZ") | mktime end) as $mergedTimestamp |
+                if $mergedTimestamp == null then null else
+                (((($mergedTimestamp - $createdTimestamp) / 3600) * 100 | floor) / 100) end)
 
-    relations:
+          relations:
             service: .head.repo.name
 ```
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_port_app_config.mdx
@@ -37,7 +37,14 @@ resources:
             createdAt: ".created_at"
             prNumber: ".id"
             link: ".html_url"
-          relations:
+            leadTimeHours: >-
+               (.created_at as $createdAt | .merged_at as $mergedAt |
+               ($createdAt | sub("\\..*Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) as $createdTimestamp |
+               ($mergedAt | if . == null then null else sub("\\..*Z$"; "Z") |
+               strptime("%Y-%m-%dT%H:%M:%SZ") | mktime end) as $mergedTimestamp |
+               if $mergedTimestamp == null then null else ($mergedTimestamp - $createdTimestamp) / 3600 end)
+
+    relations:
             service: .head.repo.name
 ```
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_pull_request_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_pull_request_blueprint.mdx
@@ -53,6 +53,10 @@
       "link": {
         "format": "url",
         "type": "string"
+      },
+      "leadTimeHours": {
+        "title": "Lead Time in hours",
+        "type": "number",
       }
     },
     "required": []
@@ -63,11 +67,6 @@
       "title": "Days Old",
       "icon": "DefaultProperty",
       "calculation": "(now / 86400) - (.properties.updatedAt | capture(\"(?<date>\\\\d{4}-\\\\d{2}-\\\\d{2})\") | .date | strptime(\"%Y-%m-%d\") | mktime / 86400) | floor",
-      "type": "number"
-    },
-    "lead_time_days": {
-      "title": "Lead time (Days)",
-      "calculation": ".properties.createdAt as $createdAt | .properties.mergedAt as $mergedAt | ($createdAt | sub(\"\\\\..*Z$\"; \"Z\") | strptime(\"%Y-%m-%dT%H:%M:%SZ\") | mktime) as $createdTimestamp | ($mergedAt | if . == null then null else sub(\"\\\\..*Z$\"; \"Z\") | strptime(\"%Y-%m-%dT%H:%M:%SZ\") | mktime end) as $mergedTimestamp | if $mergedTimestamp == null then null else ($mergedTimestamp - $createdTimestamp) / 86400 end",
       "type": "number"
     }
   },

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_pull_request_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_pull_request_blueprint.mdx
@@ -56,7 +56,7 @@
       },
       "leadTimeHours": {
         "title": "Lead Time in hours",
-        "type": "number",
+        "type": "number"
       }
     },
     "required": []


### PR DESCRIPTION
# Description
The lead time property was originally set as a calculated field based on other properties like `createdAt` and `mergedAt`. However, since this calculation was performed dynamically ('on the fly'), it couldn't be mirrored as a predefined property. Upon further investigation, we realized that both `createdAt` and `mergedAt` are already available in the API response. As a result, there is no need to compute lead time as a calculated property. We've updated the blueprint and mapping configuration to directly ingest these values from the API, removing the need for on-the-fly calculations.

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
-  Resource mapping (`/build-your-software-catalog/sync-data-to-catalog/git/github/examples/resource-mapping-examples#map-repositories-and-pull-requests)
