### PR TITLE
Fixed incorrect blueprint in mapping in connect GitHub CODEOWNERS with Service, Team & User guide

### DIFF
--- a/docs/guides/all/connect-github-codeowners-with-service-team-and-user.md
+++ b/docs/guides/all/connect-github-codeowners-with-service-team-and-user.md
@@ -305,7 +305,7 @@ resources:
         mappings:
           identifier: .item.component | gsub(" "; "_") | gsub("&"; "and") | gsub("-"; "")
           title: .item.component
-          blueprint: '"Component"'
+          blueprint: '"githubCodeowners"'
           properties:
             codeowners_file_patterns: .item.patterns
           relations:


### PR DESCRIPTION
# Description

The mapping referenced a `Component` blueprint which is does not exist, I have updated this to point to the right blueprint `githubCodeowners`

## Updated docs pages

- Blueprint (`docs/guides/all/connect-github-codeowners-with-service-team-and-user.md`)