### PR TITLE
PORT-10939 Incorrect property name in documentation for data sync to catalog.

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_pull_request_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_pull_request_blueprint.mdx
@@ -66,7 +66,7 @@
     "days_old": {
       "title": "Days Old",
       "icon": "DefaultProperty",
-      "calculation": "(now / 86400) - (.properties.updatedAt | capture(\"(?<date>\\\\d{4}-\\\\d{2}-\\\\d{2})\") | .date | strptime(\"%Y-%m-%d\") | mktime / 86400) | floor",
+      "calculation": "(now / 86400) - (.properties.createdAt | capture(\"(?<date>\\\\d{4}-\\\\d{2}-\\\\d{2})\") | .date | strptime(\"%Y-%m-%d\") | mktime / 86400) | floor",
       "type": "number"
     }
   },


### PR DESCRIPTION
# Description

using `.properties.updatedAt` to calculate the days old. This property represents the last time the PR was updated, not when it was created. To calculate the total number of days the PR has been open, you should use `.properties.createdAt`.


## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- Mapping Examples (`/build-your-software-catalog/sync-data-to-catalog/git/github/examples/resource-mapping-examples#map-repositories-and-pull-requests`)
