### PR TITLE
Add a note on new repos needing a commit for resync pickup

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
@@ -161,20 +161,23 @@ By default, if `appHost` is provided, the integration will create group webhooks
 
 #### System Webhooks
 
-To create a system hook there are two options:
+To create a system hook in GitLab, you must set `useSystemHook: true` and choose one of these setup methods:
 
-:::note
-In both options you'll need to provide the `useSystemHook` parameter with the value `true`.
+1. **Automatic Setup** - Provide a token with admin privileges using the `tokenMapping` parameter
+2. **Manual Setup** - Create the system hook yourself in GitLab:
+   - Follow GitLab's [system hook setup guide](https://docs.gitlab.com/ee/administration/system_hooks.html#create-a-system-hook)
+   - Set the URL to `{appHost}/integration/system/hook` (e.g., `https://my-gitlab-integration.com/integration/system/hook`)
+   - Enable the supported triggers: `push` and `merge_request`
+
+:::info Repository Setup and Initial Commit
+Due to GitLab webhook limitations, new repositories require special handling:
+
+- A repository will only appear in Port after its first commit
+- This is because GitLab webhooks don't support `project_create` events
+- Empty repositories (no commits) will only appear after the next scheduled resync
+
+For more details, see GitLab's [webhook events documentation](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html).
 :::
-
-1. Provide a token with admin privileges in GitLab using the `tokenMapping` parameter.
-   - When choosing this option, the integration will create the system hook in your GitLab account automatically.
-2. Create the system hook manually
-   - Follow the instructions for creating a system hook in GitLab [here](https://docs.gitlab.com/ee/administration/system_hooks.html#create-a-system-hook).
-   - In the `URL` field, provide the `appHost` parameter value with the path `/integration/system/hook`. e.g. `https://my-gitlab-integration.com/integration/system/hook`.
-   - From the `Triggers` section, the GitLab integration currently supports the following events:
-      - `push`
-      - `merge_request`
 
 ![GitLab System Hook](/img/integrations/gitlab/GitLabSystemHook.png)
 
@@ -495,19 +498,5 @@ pipeline {
 
 </Tabs>
 
-### FAQ
 
-#### Do I need to commit to a new repository for it to appear in Port when using GitLab?
 
-<details>
-<summary><b>Answer (click to expand)</b></summary>
-
-Yes, a commit is necessary for a new repository to appear in Port when using GitLab. Here's why:
-
-- **Webhook Limitations**: GitLab does not support `project_create` events for system hooks. This means that simply creating a new repository will not trigger a webhook event to update Port.
-- **Initial Commit Requirement**: To have the repository appear in Port, you need to make an initial commit. This action will trigger a webhook event (if configured) and update Port in real-time.
-- **Scheduled Resync**: If a repository is created without an initial commit, it will be picked up during the next scheduled resync.
-
-This behavior is due to the current capabilities of GitLab's webhook system. For more information on available webhook events in GitLab, see the [official GitLab documentation on webhook events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html).
-
-</details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
@@ -27,7 +27,6 @@ This page outlines the following steps:
 - If you choose the real-time & always-on installation method, a Kubernetes cluster to install the integration on.
 - Your Port user role is set to `Admin`.
 
-
 ## Setup
 
 ### Create a GitLab group access token
@@ -495,3 +494,20 @@ pipeline {
 </TabItem>
 
 </Tabs>
+
+### FAQ
+
+#### Do I need to commit to a new repository for it to appear in Port when using GitLab?
+
+<details>
+<summary><b>Answer (click to expand)</b></summary>
+
+Yes, a commit is necessary for a new repository to appear in Port when using GitLab. Here's why:
+
+- **Webhook Limitations**: GitLab does not support `project_create` events for system hooks. This means that simply creating a new repository will not trigger a webhook event to update Port.
+- **Initial Commit Requirement**: To have the repository appear in Port, you need to make an initial commit. This action will trigger a webhook event (if configured) and update Port in real-time.
+- **Scheduled Resync**: If a repository is created without an initial commit, it will be picked up during the next scheduled resync.
+
+This behavior is due to the current capabilities of GitLab's webhook system. For more information on available webhook events in GitLab, see the [official GitLab documentation on webhook events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html).
+
+</details>


### PR DESCRIPTION
## Description
This PR adds documentation clarifying GitLab repository sync behavior, specifically addressing the limitations around new repository detection and initial commits.

### Changes
- Added an info callout explaining GitLab system hook webhook limitations
- Clarified that new repositories require an initial commit to trigger webhook events
- Added information about resync behavior for empty repositories
- Reorganized the system webhooks section for better readability

### Context
This documentation update was [prompted by this slack thread](https://getport.slack.com/archives/C0799SR843F/p1729616275142109) about repository sync behavior in the GitLab Ocean integration. Specifically:
- Empty repositories (those without commits) are only detected during scheduled resyncs
- GitLab doesn't provide webhook events for project creation
- A repository needs at least one commit to trigger webhook events

### References
- [GitLab Webhook Events Documentation](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html)
- Related support thread discussing repository sync behavior

## Updated docs pages

Please also include the path for the updated docs

- GitLab Installation (`docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md`)

