### PR TITLE
Port 11112 azure devops releases

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_supported_resources.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_supported_resources.mdx
@@ -11,5 +11,7 @@ The following resources can be used to map data from Azure DevOps, it is possibl
 - [`member`](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/teams/get-team-members-with-extended-properties?view=azure-devops-rest-7.1&tabs=HTTP#teammember)
 - [`work-item`](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/wiql/query-by-wiql?view=azure-devops-rest-7.1&tabs=HTTP)
 - [`board`](https://learn.microsoft.com/en-us/rest/api/azure/devops/work/boards/list?view=azure-devops-rest-7.1)
+- [`release`](https://learn.microsoft.com/en-us/rest/api/azure/devops/release/releases?view=azure-devops-rest-7.1)
+
 
 :::

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-release/_azuredevops_exporter_example_release_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-release/_azuredevops_exporter_example_release_blueprint.mdx
@@ -1,0 +1,74 @@
+<details>
+<summary>Release blueprint</summary>
+
+```json showLineNumbers
+  {
+    "identifier": "release",
+    "title": "Release",
+    "icon": "AzureDevops",
+    "schema": {
+      "properties": {
+        "status": {
+          "title": "Status",
+          "type": "string",
+          "icon": "DefaultProperty",
+          "description": "The current status of the release"
+        },
+        "reason": {
+          "title": "Reason",
+          "type": "string",
+          "description": "The reason for the release creation"
+        },
+        "createdDate": {
+          "title": "Created Date",
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time when the release was created"
+        },
+        "modifiedDate": {
+          "title": "Modified Date",
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time when the release was last modified"
+        },
+        "createdBy": {
+          "title": "Created By",
+          "type": "string",
+          "icon": "User",
+          "description": "The person who created the release"
+        },
+        "modifiedBy": {
+          "title": "Modified By",
+          "type": "string",
+          "icon": "User",
+          "description": "The person who last modified the release"
+        },
+        "definitionName": {
+          "title": "Definition Name",
+          "type": "string",
+          "description": "The name of the release definition"
+        },
+        "link": {
+          "title": "Link",
+          "type": "string",
+          "format": "url",
+          "icon": "AzureDevops",
+          "description": "Link to the release in Azure DevOps"
+        }
+      },
+      "required": []
+    },
+    "mirrorProperties": {},
+    "calculationProperties": {},
+    "aggregationProperties": {},
+    "relations": {
+      "project": {
+        "title": "Project",
+        "target": "project",
+        "required": true,
+        "many": false
+      }
+    }
+  }
+```
+</details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-release/_azuredevops_exporter_example_release_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-release/_azuredevops_exporter_example_release_port_app_config.mdx
@@ -1,0 +1,31 @@
+<details>
+
+<summary>Ocean integration configuration</summary>
+
+```yaml showLineNumbers
+resources:
+  - kind: release
+    selector:
+      query: 'true'
+    port:
+      entity:
+        mappings:
+          identifier: .projectReference.id + "-" + (.id | tostring) | gsub(" "; "")
+          title: .name
+          blueprint: '"release"'
+          properties:
+            status: .status
+            reason: .reason
+            createdDate: .createdOn
+            modifiedDate: .modifiedOn
+            createdBy: .createdBy.uniqueName
+            modifiedBy: .modifiedBy.uniqueName
+            definitionName: .releaseDefinition.name
+            link: ._links.web.href | gsub("_release?releaseId="; "")
+          relations:
+            project: .projectReference.id | gsub(" "; "")
+
+
+```
+
+</details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md
@@ -22,6 +22,9 @@ import PortWorkItemAppConfig from './example-project/\_azuredevops_exporter_exam
 import BoardBlueprint from './example-board/\_azuredevops_exporter_example_board_blueprint.mdx'
 import PortBoardAppConfig from './example-board/\_azuredevops_exporter_example_board_port_app_config.mdx'
 
+import ReleaseBlueprint from './example-release/\_azuredevops_exporter_example_release_blueprint.mdx'
+import PortReleaseAppConfig from './example-release/\_azuredevops_exporter_example_release_port_app_config.mdx'
+
 
 # Examples
 
@@ -141,6 +144,24 @@ You can use the following Port blueprint definitions and integration configurati
 
 After creating the blueprints and saving the integration configuration, you will see new entities in Port matching your Azure DevOps boards.
 
+
+## Mapping releases
+
+The example below shows how to ingest Azure DevOps Releases into Port.  
+You can use the following Port blueprint definitions and integration configuration:
+
+
+<ReleaseBlueprint/>
+
+<PortReleaseAppConfig/>
+
+
+:::tip To Learn more
+- Click [here](https://learn.microsoft.com/en-us/rest/api/azure/devops/release/releases/list?view=azure-devops-rest-7.1&tabs=HTTP) for the Azure DevOps release object structure.
+:::
+
+
+After creating the blueprints and saving the integration configuration, you will see new entities in Port matching your releases.
 
 ## Mapping supported resources
 


### PR DESCRIPTION
# Description

This change adds documentation for mapping Azure DevOps Release resources within Port's Azure DevOps integration. 
## Added docs pages

- **Azure DevOps Release Example Blueprint**  
  Path: `/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-release/_azuredevops_exporter_example_release_blueprint.mdx`

- **Azure DevOps Release Example Port App Config**  
  Path: `/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-release/_azuredevops_exporter_example_release_port_app_config.mdx`

## Updated docs pages

- **Azure DevOps Examples**  
  Path: `/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md`  
  Changes:  
  - Added a new section for mapping Azure DevOps releases.
  - Referenced the new blueprint and configuration example pages.
  - Linked to the Azure DevOps API documentation for further reference.

- **Azure DevOps Supported Resources**  
  Path: `/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_supported_resources.mdx`  
  Changes:  
  - Added "release" as a supported resource, with a link to relevant API documentation.
