### PR TITLE
Update jenkins.md

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/cicd/jenkins/jenkins.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cicd/jenkins/jenkins.md
@@ -628,6 +628,10 @@ resources:
 
 ### Build
 
+:::note Build Limit
+The integration fetches up to 100 builds per Jenkins job, allowing you to view the 100 latest builds in Port for each job.
+:::
+
 <details>
 <summary>Build blueprint</summary>
 


### PR DESCRIPTION
# Description

Add note on max number of builds that can be fetched per job in Jenkins integration

## Updated docs pages

Please also include the path for the updated docs

- Jenkins Integration (`build-your-software-catalog/sync-data-to-catalog/cicd/jenkins/#build`)
