### PR TITLE
Updated project relation in work-item example mapping in ADO

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-project/_azuredevops_exporter_example_work_item_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-project/_azuredevops_exporter_example_work_item_port_app_config.mdx
@@ -26,7 +26,7 @@ resources:
             createdDate: .fields."System.CreatedDate"
             changedDate: .fields."System.ChangedDate"
           relations:
-            project: .fields."System.TeamProject" | gsub(" "; "")
+            project: .__projectId | gsub(" "; "")
 
 ```
 


### PR DESCRIPTION
# Description

Updated the relationship in the work-item mapping in the ADO docs to use project ID to for relation to project. This harmonizes the docs with the integration defaults

## Updated docs pages

Please also include the path for the updated docs

- work-item mapping (`/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples`)

