### PR TITLE
Adds assigned to to the ADO work_items blueprint and kind config

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-project/_azuredevops_exporter_example_work_item_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-project/_azuredevops_exporter_example_work_item_blueprint.mdx
@@ -61,6 +61,12 @@
         "icon": "User",
         "description": "The person who last changed the work item"
       },
+      "assignedTo": {
+        "title": "Assigned To",
+        "type": "string",
+        "icon": "User",
+        "description": "The person assigned to this work item"
+      },
       "createdDate": {
         "title": "Created Date",
         "type": "string",

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-project/_azuredevops_exporter_example_work_item_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-project/_azuredevops_exporter_example_work_item_port_app_config.mdx
@@ -23,6 +23,7 @@ resources:
             reason: .fields."System.Reason"
             createdBy: .fields."System.CreatedBy".displayName
             changedBy: .fields."System.ChangedBy".displayName
+            assignedTo: .fields."System.AssignedTo".displayName
             createdDate: .fields."System.CreatedDate"
             changedDate: .fields."System.ChangedDate"
           relations:


### PR DESCRIPTION
# Description
Added the `assignedTo` field to the Azure DevOps work items integration docs.

## Added docs pages
N/A

## Updated docs pages
- Azure DevOps Work Item Blueprint (`/integrations/azure-devops/example-project/_azuredevops_exporter_example_work_item_blueprint.mdx`)
  - Added `assignedTo` property to schema.
- Azure DevOps Integration Configuration (`/integrations/azure-devops/example-project/_azuredevops_exporter_example_work_item_port_app_config.mdx`) 
  - Added `assignedTo` mapping using System.AssignedTo.displayName field