### PR TITLE
Highlight limitations of ingesting member emails

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-member/_gitlab_exporter_example_member_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-member/_gitlab_exporter_example_member_port_app_config.mdx
@@ -3,9 +3,6 @@
 <summary> Ocean integration configuration </summary>
 
 ```yaml showLineNumbers
-deleteDependentEntities: true
-createMissingRelatedEntities: true
-enableMergeEntity: true
 resources:
   - kind: group-with-members # replace with `project-with-members` to retrieve members from projects
     selector:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-projects-members/_gitlab_exporter_example_project_member_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-projects-members/_gitlab_exporter_example_project_member_port_app_config.mdx
@@ -3,9 +3,6 @@
 <summary> Ocean integration configuration </summary>
 
 ```yaml showLineNumbers
-deleteDependentEntities: true
-createMissingRelatedEntities: true
-enableMergeEntity: true
 resources:
   - kind: project-with-members
     selector:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/examples.md
@@ -220,6 +220,12 @@ In the following example you will ingest your GitLab members to Port, you may us
 
 :::
 
+:::caution Limitation
+<b> Offering: GitLab Free Plan </b>
+- Primary email addresses are not available for GitLab Free plan users.
+:::
+
+
 <MemberBlueprint/>
 <MemberPortAppConfig/>
 
@@ -278,6 +284,10 @@ In the following example you will ingest your GitLab groups and their members to
 
 In the following example you will ingest your GitLab projects and their members to Port, you may use the following Port blueprint definitions and integration configuration:
 
+:::caution Limitation
+Real time webhook events are not supported for the `project-with-members` kind.
+:::
+
 <ProjectWithMemberRelationBlueprint/>
 <ProjectMemberPortAppConfig/>
 
@@ -285,8 +295,7 @@ In the following example you will ingest your GitLab projects and their members 
 
 - Refer to the [setup](gitlab.md#setup) section to learn more about the integration configuration setup process.
 - We leverage [JQ JSON processor](https://stedolan.github.io/jq/manual/) to map and transform GitLab objects to Port entities.
-- Click [Here](https://docs.gitlab.com/ee/api/groups.html#list-a-groups-projects) for the GitLab project object structure.
-- Click [Here](https://docs.gitlab.com/ee/api/issues.html#list-project-issues) for the GitLab issue object structure.
+- Click [Here](https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project) for the GitLab project or group member object structure.
 
 :::
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/gitlab.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/gitlab.md
@@ -24,6 +24,8 @@ It is possible to reference any field that appears in the API responses linked b
 - [`pipeline`](https://docs.gitlab.com/ee/api/pipelines.html#get-a-single-pipeline)
 - [`group`](https://docs.gitlab.com/ee/api/groups.html#details-of-a-group)
 - [`file`](https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository)
+- [`members`](https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project)
+
 
 ## Setup
 


### PR DESCRIPTION
# Description

Clarify limitations regarding member primary email availability for GitLab Free plan users and the lack of real-time webhook events for the `project-with-members` kind.

## Updated docs pages

Please also include the path for the updated docs

- Examples (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab/examples`)
