### PR TITLE
must install ResourceGraph before Resource blueprint

### DIFF
--- a/docs/guides/all/humanitec-integration.md
+++ b/docs/guides/all/humanitec-integration.md
@@ -146,4 +146,5 @@ jobs:
 </details>
 
 
-Done! any change that happens to your application, environment, workloads or resources in Humanitec will be synced to port on the schedule interval defined in the github workflow.
+Done! Any change that happens to your application, environment, workloads or resources in Humanitec will be synced to Port on the schedule interval defined in the GitHub workflow.
+

--- a/docs/guides/all/humanitec-integration.md
+++ b/docs/guides/all/humanitec-integration.md
@@ -41,9 +41,9 @@ Create the following blueprint definitions in port:
 
 <HumanitecWorkloadBlueprint/>
 
-<HumanitecResourceBlueprint/>
-
 <HumanitecResourceGraphBlueprint/>
+
+<HumanitecResourceBlueprint/>
 
 :::tip Blueprint Properties
 You may select the blueprints depending on what you want to track in your Humanitec account.


### PR DESCRIPTION
# Description

The ResourceGraph blueprint must be installed prior to the Resource blueprint, as it is referenced by it.

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
