### PR TITLE
SonarQube GA API for projects

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/examples.md
@@ -34,6 +34,20 @@ To view and test the integration's mapping against examples of the third-party A
         "icon": "Clock",
         "title": "Last Analysis Date"
       },
+      "qualityGateStatus": {
+        "title": "Quality Gate Status",
+        "type": "string",
+        "enum": [
+          "OK",
+          "WARN",
+          "ERROR"
+        ],
+        "enumColors": {
+          "OK": "green",
+          "WARN": "yellow",
+          "ERROR": "red"
+        }
+      },
       "numberOfBugs": {
         "type": "number",
         "title": "Number Of Bugs"
@@ -63,15 +77,73 @@ To view and test the integration's mapping against examples of the third-party A
         "icon": "Git",
         "title": "Main Branch"
       },
-      "tags": {
-        "type": "array",
-        "title": "Tags"
+      "mainBranchLastAnalysisDate": {
+        "type": "string",
+        "format": "date-time",
+        "icon": "Clock",
+        "title": "Main Branch Last Analysis Date"
+      },
+      "revision": {
+        "type": "string",
+        "title": "Revision"
+      },
+      "managed": {
+        "type": "boolean",
+        "title": "Managed"
       }
     },
     "required": []
   },
   "mirrorProperties": {},
   "calculationProperties": {},
+  "aggregationProperties": {
+    "criticalOpenIssues": {
+      "title": "Number Of Open Critical Issues",
+      "type": "number",
+      "target": "sonarQubeIssue",
+      "query": {
+        "combinator": "and",
+        "rules": [
+          {
+            "property": "status",
+            "operator": "in",
+            "value": ["OPEN", "REOPENED"]
+          },
+          {
+            "property": "severity",
+            "operator": "=",
+            "value": "CRITICAL"
+          }
+        ]
+      },
+      "calculationSpec": {
+        "calculationBy": "entities",
+        "func": "count"
+      }
+    },
+    "numberOfOpenIssues": {
+      "title": "Number Of Open Issues",
+      "type": "number",
+      "target": "sonarQubeIssue",
+      "query": {
+        "combinator": "and",
+        "rules": [
+          {
+            "property": "status",
+            "operator": "in",
+            "value": [
+              "OPEN",
+              "REOPENED"
+            ]
+          }
+        ]
+      },
+      "calculationSpec": {
+        "calculationBy": "entities",
+        "func": "count"
+      }
+    }
+  },
   "relations": {}
 }
 ```
@@ -82,7 +154,9 @@ To view and test the integration's mapping against examples of the third-party A
 <summary><b>Integration configuration (Click to expand)</b></summary>
 
 :::tip filter projects
-The integration provides an option to filter the data that is retrieved from the SonarQube API using the following attributes:
+The integration provides an option to filter the data that is retrieved from the SonarQube API depending on the integration version based on the following attributes:
+
+<h3>SonarQube integration version <\= 0.1.114</h3>
 
 1. `query`: Limits the search to component names that contain the supplied string
 2. `alertStatus`: To filter a project's quality gate status. Accepts a list of values such as `OK`, `ERROR` and `WARN`
@@ -91,6 +165,17 @@ The integration provides an option to filter the data that is retrieved from the
 5. `qualifier`: To filter on a component qualifier. Accepts values such as `TRK` (for projects only) and `APP` (for applications only)
 
 These attributes can be enabled using the path: `selector.apiFilters.filter`. By default, the integration fetches only SonarQube projects using the `qualifier` attribute.
+
+<h3>SonarQube integration version <\= 0.1.114</h3>
+1. `analyzed_before`: To retrieve projects analyzed before the given date. Accepts date format like so `2017-10-19` or `2017-10-19T13:00:00+0200`
+
+2. `on_provisioned_only`: To retrieve projects on provisioned only. Accepts boolean `true` or `false`.
+
+3. `projects`: List of projects to retrieve only. Specify the projects as an array of keys.
+
+4. `qualifier`: To filter based on the project's qualifier. Possible values are `TRK`, `VW` and `APP`. Defaults to `TRK`.
+
+These attributes can be enabled using the `selector` path.
 :::
 
 :::tip Define your own metrics
@@ -100,6 +185,8 @@ Besides filtering the API data, the integration provides a mechanism to allow us
 :::note Supported Sonar environment
 Please note that the API filters are supported on on-premise Sonar environments (SonarQube) only, and will not work on SonarCloud.
 :::
+
+<h3>Project mapping for integration version `<= 0.1.114`</h3>
 
 ```yaml showLineNumbers
 createMissingRelatedEntities: true
@@ -141,6 +228,50 @@ resources:
             mainBranch: .__branch.name
             tags: .tags
 ```
+
+
+<h3>Project mapping for integratiion version `>= 0.1.115`</h3>
+
+```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: ga_projects
+    selector:
+      query: 'true'
+      metrics:
+        - code_smells
+        - coverage
+        - bugs
+        - vulnerabilities
+        - duplicated_files
+        - security_hotspots
+        - new_violations
+        - new_coverage
+        - new_duplicated_lines_density
+    port:
+      entity:
+        mappings:
+          blueprint: '"sonarQubeGAProject"'
+          identifier: .key
+          title: .name
+          properties:
+            organization: .organization
+            link: .__link
+            qualityGateStatus: .__branch.status.qualityGateStatus
+            lastAnalysisDate: .analysisDate
+            numberOfBugs: .__measures[]? | select(.metric == "bugs") | .value
+            numberOfCodeSmells: .__measures[]? | select(.metric == "code_smells") | .value
+            numberOfVulnerabilities: .__measures[]? | select(.metric == "vulnerabilities") | .value
+            numberOfHotSpots: .__measures[]? | select(.metric == "security_hotspots") | .value
+            numberOfDuplications: .__measures[]? | select(.metric == "duplicated_files") | .value
+            coverage: .__measures[]? | select(.metric == "coverage") | .value
+            mainBranch: .__branch.name
+            mainBranchLastAnalysisDate: .__branch.analysisDate
+            revision: .revision
+            managed: .managed
+```
+
 </details>
 
 ## Issue

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
@@ -437,12 +437,13 @@ Here is an example of the payload structure from SonarQube:
   "key": "PeyGis_Chatbot_For_Social_Media_Transaction",
   "name": "Chatbot_For_Social_Media_Transaction",
   "isFavorite": true,
-  "tags": [],
   "visibility": "public",
   "eligibilityStatus": "COMPLETED",
   "eligible": true,
   "isNew": false,
-  "analysisDateAllBranches": "2023-09-09T03:03:20+0200",
+  "lastAnalysisDate": "2017-03-02T15:21:47+0300",
+  "revision": "7be96a94ac0c95a61ee6ee0ef9c6f808d386a355",
+  "managed": false,
   "__measures": [
     {
       "metric": "bugs",
@@ -717,7 +718,9 @@ The combination of the sample payload and the Ocean configuration generates the 
     "numberOfHotSpots": 8,
     "numberOfDuplications": 2,
     "mainBranch": "master",
-    "tags": []
+    "mainBranchLastAnalysisDate": "2023-09-07T12:38:41.000Z",
+    "revision": "7be96a94ac0c95a61ee6ee0ef9c6f808d386a355",
+    "managed": true
   },
   "relations": {},
   "icon": "sonarqube"
@@ -804,6 +807,350 @@ The combination of the sample payload and the Ocean configuration generates the 
   }
 }
 ```
+
+</details>
+
+## Migration from SonarQube integration version <= 0.1.114
+Versions prior to `v0.1.115` used SonarQube's internal API for components to retrieve projects. However, this API apart from being internal and subject to change without notification by SonarQube is also inconsistent and will intermittently return an empty response causing previously ingested entities to be deleted. This deletion is because Ocean and therefore Port assumes these entities no longer exist.
+
+To remedy this, we have switched to the globally available API for projects instead for new users of the SonarQube integration. This comes with a few changes below
+
+### Changes to the SonarQube integration
+
+- The `project` kind is deprecated in support for the `ga_project` kind.
+
+- Since `tags` property is only available with the internal API, the tags property will read `null` for existing users.
+
+- Minor but backwards compatible changes have been made to the `sonarQubeProject` blueprint:
+
+
+<details>
+
+<summary><b>`<=v0.1.114` `sonarqubeProject` blueprint (Click to expand)</b></summary>
+
+```json showLineNumbers
+{
+    "identifier": "sonarQubeProject",
+    "title": "SonarQube Project",
+    "icon": "sonarqube",
+    "schema": {
+      "properties": {
+        "organization": {
+          "type": "string",
+          "title": "Organization",
+          "icon": "TwoUsers"
+        },
+        "link": {
+          "type": "string",
+          "format": "url",
+          "title": "Link",
+          "icon": "Link"
+        },
+        "lastAnalysisDate": {
+          "type": "string",
+          "format": "date-time",
+          "icon": "Clock",
+          "title": "Last Analysis Date"
+        },
+        "qualityGateStatus": {
+          "title": "Quality Gate Status",
+          "type": "string",
+          "enum": [
+            "OK",
+            "WARN",
+            "ERROR"
+          ],
+          "enumColors": {
+            "OK": "green",
+            "WARN": "yellow",
+            "ERROR": "red"
+          }
+        },
+        "numberOfBugs": {
+          "type": "number",
+          "title": "Number Of Bugs"
+        },
+        "numberOfCodeSmells": {
+          "type": "number",
+          "title": "Number Of CodeSmells"
+        },
+        "numberOfVulnerabilities": {
+          "type": "number",
+          "title": "Number Of Vulnerabilities"
+        },
+        "numberOfHotSpots": {
+          "type": "number",
+          "title": "Number Of HotSpots"
+        },
+        "numberOfDuplications": {
+          "type": "number",
+          "title": "Number Of Duplications"
+        },
+        "coverage": {
+          "type": "number",
+          "title": "Coverage"
+        },
+        "mainBranch": {
+          "type": "string",
+          "icon": "Git",
+          "title": "Main Branch"
+        },
+        "tags": {
+          "type": "array",
+          "title": "Tags"
+        }
+      },
+      "required": []
+    },
+    "mirrorProperties": {},
+    "calculationProperties": {},
+    "aggregationProperties": {
+      "criticalOpenIssues": {
+        "title": "Number Of Open Critical Issues",
+        "type": "number",
+        "target": "sonarQubeIssue",
+        "query": {
+          "combinator": "and",
+          "rules": [
+            {
+              "property": "status",
+              "operator": "in",
+              "value": ["OPEN", "REOPENED"]
+            },
+            {
+              "property": "severity",
+              "operator": "=",
+              "value": "CRITICAL"
+            }
+          ]
+        },
+        "calculationSpec": {
+          "calculationBy": "entities",
+          "func": "count"
+        }
+      },
+      "numberOfOpenIssues": {
+        "title": "Number Of Open Issues",
+        "type": "number",
+        "target": "sonarQubeIssue",
+        "query": {
+          "combinator": "and",
+          "rules": [
+            {
+              "property": "status",
+              "operator": "in",
+              "value": [
+                "OPEN",
+                "REOPENED"
+              ]
+            }
+          ]
+        },
+        "calculationSpec": {
+          "calculationBy": "entities",
+          "func": "count"
+        }
+      }
+    },
+    "relations": {}
+  }
+```
+
+</details>
+
+<details>
+
+<summary><b>`>=v0.1.115` `sonarqubeProject` blueprint (Click to expand)</b></summary>
+
+```json showLineNumbers
+{
+    "identifier": "sonarQubeProject",
+    "title": "SonarQube Project",
+    "icon": "sonarqube",
+    "schema": {
+      "properties": {
+        "organization": {
+          "type": "string",
+          "title": "Organization",
+          "icon": "TwoUsers"
+        },
+        "link": {
+          "type": "string",
+          "format": "url",
+          "title": "Link",
+          "icon": "Link"
+        },
+        "lastAnalysisDate": {
+          "type": "string",
+          "format": "date-time",
+          "icon": "Clock",
+          "title": "Last Analysis Date"
+        },
+        "qualityGateStatus": {
+          "title": "Quality Gate Status",
+          "type": "string",
+          "enum": [
+            "OK",
+            "WARN",
+            "ERROR"
+          ],
+          "enumColors": {
+            "OK": "green",
+            "WARN": "yellow",
+            "ERROR": "red"
+          }
+        },
+        "numberOfBugs": {
+          "type": "number",
+          "title": "Number Of Bugs"
+        },
+        "numberOfCodeSmells": {
+          "type": "number",
+          "title": "Number Of CodeSmells"
+        },
+        "numberOfVulnerabilities": {
+          "type": "number",
+          "title": "Number Of Vulnerabilities"
+        },
+        "numberOfHotSpots": {
+          "type": "number",
+          "title": "Number Of HotSpots"
+        },
+        "numberOfDuplications": {
+          "type": "number",
+          "title": "Number Of Duplications"
+        },
+        "coverage": {
+          "type": "number",
+          "title": "Coverage"
+        },
+        "mainBranch": {
+          "type": "string",
+          "icon": "Git",
+          "title": "Main Branch"
+        },
+        "mainBranchLastAnalysisDate": {
+          "type": "string",
+          "format": "date-time",
+          "icon": "Clock",
+          "title": "Main Branch Last Analysis Date"
+        },
+        "revision": {
+          "type": "string",
+          "title": "Revision"
+        },
+        "managed": {
+          "type": "boolean",
+          "title": "Managed"
+        }
+      },
+      "required": []
+    },
+    "mirrorProperties": {},
+    "calculationProperties": {},
+    "aggregationProperties": {
+      "criticalOpenIssues": {
+        "title": "Number Of Open Critical Issues",
+        "type": "number",
+        "target": "sonarQubeIssue",
+        "query": {
+          "combinator": "and",
+          "rules": [
+            {
+              "property": "status",
+              "operator": "in",
+              "value": ["OPEN", "REOPENED"]
+            },
+            {
+              "property": "severity",
+              "operator": "=",
+              "value": "CRITICAL"
+            }
+          ]
+        },
+        "calculationSpec": {
+          "calculationBy": "entities",
+          "func": "count"
+        }
+      },
+      "numberOfOpenIssues": {
+        "title": "Number Of Open Issues",
+        "type": "number",
+        "target": "sonarQubeIssue",
+        "query": {
+          "combinator": "and",
+          "rules": [
+            {
+              "property": "status",
+              "operator": "in",
+              "value": [
+                "OPEN",
+                "REOPENED"
+              ]
+            }
+          ]
+        },
+        "calculationSpec": {
+          "calculationBy": "entities",
+          "func": "count"
+        }
+      }
+    },
+    "relations": {}
+  }
+
+```
+
+</details>
+
+- If you however, choose to stick with the internal API with the `project` kind, use the new blueprint with the following mapping:
+
+
+<details>
+
+<summary><b>Project mapping for `project` kind(Click to expand)</b></summary>
+
+```yaml showLineNumbers
+createMissingRelatedEntities: true
+deleteDependentEntities: true
+resources:
+  - kind: projects
+    selector:
+      query: 'true'
+      apiFilters:
+        filter:
+          qualifier: TRK
+      metrics:
+        - code_smells
+        - coverage
+        - bugs
+        - vulnerabilities
+        - duplicated_files
+        - security_hotspots
+        - new_violations
+        - new_coverage
+        - new_duplicated_lines_density
+    port:
+      entity:
+        mappings:
+          blueprint: '"sonarQubeProject"'
+          identifier: .key
+          title: .name
+          properties:
+            organization: .organization
+            link: .__link
+            qualityGateStatus: .__branch.status.qualityGateStatus
+            lastAnalysisDate: .__branch.analysisDate
+            numberOfBugs: .__measures[]? | select(.metric == "bugs") | .value
+            numberOfCodeSmells: .__measures[]? | select(.metric == "code_smells") | .value
+            numberOfVulnerabilities: .__measures[]? | select(.metric == "vulnerabilities") | .value
+            numberOfHotSpots: .__measures[]? | select(.metric == "security_hotspots") | .value
+            numberOfDuplications: .__measures[]? | select(.metric == "duplicated_files") | .value
+            coverage: .__measures[]? | select(.metric == "coverage") | .value
+            mainBranch: .__branch.name
+            tags: .tags
+```
+
 
 </details>
 


### PR DESCRIPTION
# Description
Since the SonarQube integration is moving from the internal components API to the GA projects API, this PR documents the change and how it affects users

## Updated docs pages


- SonarQube (`/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/`)
- SonarQube Examples (`/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/examples/`)
