### PR TITLE
PORT-11787 Updating the real-time-updates section in the Scheduled CI for all integrations

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog/datadog.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog/datadog.md
@@ -186,7 +186,7 @@ This table summarizes the available parameters for the installation.
 This workflow/pipeline will run the Datadog integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/dynatrace/dynatrace.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/dynatrace/dynatrace.md
@@ -182,7 +182,7 @@ This table summarizes the available parameters for the installation.
 This workflow/pipeline will run the Dynatrace integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks, use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks, use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/newrelic.md
@@ -200,7 +200,7 @@ The integration uses polling to pull the configuration from Port every minute an
 This workflow/pipeline will run the New Relic integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option
 :::
 
  <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/sentry.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/sentry.md
@@ -188,7 +188,7 @@ The integration uses polling to pull the configuration from Port every minute an
 This workflow/pipeline will run the Sentry integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates 
-If you want the integration to update Port in real time you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option
+If you want the integration to update Port in real time you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option
 :::
 
  <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/argocd/argocd.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/argocd/argocd.md
@@ -258,7 +258,7 @@ Note the parameters specific to this integration, they are last in the table.
 This workflow/pipeline will run the ArgoCD integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option
 :::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cicd/octopus-deploy/octopus-deploy.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cicd/octopus-deploy/octopus-deploy.md
@@ -184,7 +184,7 @@ This table summarizes the available parameters for the installation.
 This workflow/pipeline will run the Octopus integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option
 :::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
@@ -235,7 +235,7 @@ This table summarizes the available parameters for the installation.
 This workflow/pipeline will run the Snyk integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option
 :::
 
   By default, the integration fetches **all organizations** associated with the provided Snyk token.  

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
@@ -186,7 +186,7 @@ This table summarizes the available parameters for the installation.
 This workflow/pipeline will run the SonarQube integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz.md
@@ -253,7 +253,7 @@ Note the parameters specific to this integration, they are last in the table.
 This workflow/pipeline will run the Wiz integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 <Tabs groupId="cicd-method" queryString="cicd-method">
 <TabItem value="github" label="GitHub">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly/launchdarkly.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly/launchdarkly.md
@@ -181,7 +181,7 @@ The integration uses polling to pull the configuration from Port every minute an
 This workflow/pipeline will run the LaunchDarkly integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 
  <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/installation.md
@@ -195,7 +195,7 @@ This table summarizes the available parameters for the installation.
 This pipeline will run the Azure DevOps integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 
 <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
@@ -349,7 +349,7 @@ Note the parameters specific to this integration, they are last in the table.
 This pipeline will run the GitLab integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/firehydrant.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/firehydrant.md
@@ -180,7 +180,7 @@ This table summarizes the available parameters for the installation.
 This workflow/pipeline will run the FireHydrant integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option
 :::
 
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/opsgenie/opsgenie.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/opsgenie/opsgenie.md
@@ -188,7 +188,7 @@ This table summarizes the available parameters for the installation. The paramet
 This workflow/pipeline will run the Opsgenie integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option
 :::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/pagerduty/pagerduty.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/pagerduty/pagerduty.md
@@ -190,7 +190,7 @@ This table summarizes the available parameters for the installation.
 This workflow/pipeline will run the PagerDuty integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
   <Tabs groupId="cicd-method" queryString="cicd-method">
   <TabItem value="github" label="GitHub">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/statuspage/statuspage.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/incident-management/statuspage/statuspage.md
@@ -177,7 +177,7 @@ This table summarizes the available parameters for the installation.
 This workflow/pipeline will run the Statuspage integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option
 :::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/jira.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/jira.md
@@ -187,7 +187,7 @@ This table summarizes the available parameters for the installation.
 This workflow/pipeline will run the Jira integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Realtime updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/project-management/linear/linear.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/project-management/linear/linear.md
@@ -178,7 +178,7 @@ This table summarizes the available parameters for the installation.
 This workflow/pipeline will run the Linear integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 
   <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/terraform-cloud/terraform-cloud.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/terraform-cloud/terraform-cloud.md
@@ -190,7 +190,7 @@ The integration uses polling to pull the configuration from Port every minute an
 This workflow/pipeline will run the Terraform Cloud integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 
  <Tabs groupId="cicd-method" queryString="cicd-method">

--- a/docs/generalTemplates/_integration_template.md
+++ b/docs/generalTemplates/_integration_template.md
@@ -70,7 +70,7 @@ Note the parameters specific to this integration, they are last in the table.
 This workflow/pipeline will run the X integration once and then exit, this is useful for **scheduled** ingestion of data.
 
 :::warning Real-time updates
-If you want the integration to update Port in real time using webhooks you should use the [Real Time & Always On](?installation-methods=real-time-always-on#installation) installation option.
+If you want the integration to update Port in real time using webhooks you should use the [Real-time (self-hosted)](?installation-methods=real-time-self-hosted#setup) installation option.
 :::
 
 </TabItem>


### PR DESCRIPTION
# Description

The headers of the installation types for the tabs in the integrations guide has changed to Real-time (self-hosted)
The scheduled tab (CI) references the old link to the real time and always on tab. The link has been changed to reflect the new one in all the integration guides 

## Updated docs pages

Please also include the path for the updated docs
Integration Docs (`/build-your-software-catalog/sync-data-to-catalog/`)
