### PR TITLE
Bug | Wrong format in Gitlab Issue blueprint fix

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-issue/_git_exporter_example_issue_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-issue/_git_exporter_example_issue_blueprint.mdx
@@ -53,7 +53,7 @@
           "type": "string"
         }
       }
-    },
+    }
   },
   "calculationProperties": {},
   "relations": {


### PR DESCRIPTION
# Description

deleted not needed coma in the Gitlab Issue blueprint

## Added docs pages

[Please also include the path for the added docs](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/git/gitlab/examples/#mapping-projects-and-issues)

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
