### PR TITLE
PORT-11786 Add tip on configuring webhooks for real-time updates

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/templates/_ocean_saas_installation.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/templates/_ocean_saas_installation.mdx
@@ -78,3 +78,8 @@ You may need to add these addresses to your allowlist, in order to allow Port to
 </TabItem>
 </Tabs>
 
+:::tip Real-time updates
+If the "Hosted by Port" integration doesn't automatically perform real-time updates you can manually configure webhooks to trigger immediate data ingestion.
+[Learn more about manually creating webhooks for real-time updates](#alternative-installation-via-webhook).
+:::
+


### PR DESCRIPTION


# Description

This change introduces a tip about setting up webhooks for real-time data ingestion when the default integration does not update automatically. It also includes a link to detailed instructions for manual webhook configuration. This helps users ensure timely updates in their software catalog.
## Added docs pages



## Updated docs pages

Please also include the path for the updated docs

- All integration docs that have hosted by port
