### PR TITLE
Change issue priority from `id` to `name`

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/examples/_jira_example_issue_configuration.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/examples/_jira_example_issue_configuration.mdx
@@ -15,7 +15,7 @@
          issueType: .fields.issuetype.name
          components: .fields.components
          creator: .fields.creator.emailAddress
-         priority: .fields.priority.id
+         priority: .fields.priority.name
          labels: .fields.labels
          created: .fields.created
          updated: .fields.updated

--- a/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/examples/_jira_issue_example_entity.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/examples/_jira_issue_example_entity.mdx
@@ -11,7 +11,7 @@
     "issueType": "Task",
     "components": [],
     "creator": "username@example.com.io",
-    "priority": "3",
+    "priority": "Medium",
     "created": "2023-11-06T11:02:59.000+0000",
     "updated": "2023-11-06T11:03:18.244+0000"
   },


### PR DESCRIPTION
# Description
Change issue priority from `id` to `name` to provide a better readable experience.

## Updated docs pages

- Jira (`/build-your-software-catalog/sync-data-to-catalog/project-management/jira/`)

Integration PR: https://github.com/port-labs/ocean/pull/1267
