### PR TITLE
Add Azure subscription tags to docs

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/resource_templates/subscription/_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/resource_templates/subscription/_port_app_config.mdx
@@ -14,7 +14,9 @@ resources:
           identifier: .id
           title: .display_name
           blueprint: '"azureSubscription"'
-          properties: {}
+          properties: {
+            tags: .tags
+          }
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/resource_templates/subscription/_subscription_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/resource_templates/subscription/_subscription_blueprint.mdx
@@ -8,7 +8,12 @@
   "title": "Azure Subscription",
   "icon": "Azure",
   "schema": {
-    "properties": {},
+    "properties": {
+      "tags": {
+        "title": "Tags",
+        "type": "object"
+      }
+    },
     "required": []
   },
   "mirrorProperties": {},


### PR DESCRIPTION
# Description

Aligning the default blueprint to the tags addition, based on the Ocean [repo](https://github.com/port-labs/ocean/blob/main/integrations/azure/.port/resources/port-app-config.yaml).
## Added docs pages



## Updated docs pages
- Azure resources examples
