### PR TITLE
Add support for GitLab repository labels

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_port_app_config.mdx
@@ -21,6 +21,7 @@ resources:
             namespace: .namespace.name
             fullPath: .namespace.full_path
             defaultBranch: .default_branch
+            labels: .__labels
   - kind: merge-request
     selector:
       query: "true"

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_port_app_config.mdx
@@ -7,6 +7,7 @@ resources:
   - kind: project
     selector:
       query: "true"
+      includeLabels: "true"
     port:
       entity:
         mappings:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_repository_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_repository_blueprint.mdx
@@ -37,6 +37,13 @@
       "defaultBranch": {
         "title": "Default Branch",
         "type": "string"
+      },
+      "labels": {
+        "items": {
+          "type": "object"
+        },
+        "type": "array",
+        "title": "Labels"
       }
     },
     "required": []


### PR DESCRIPTION
# Description

This PR updates the service blueprint and config mapping in the gitlab documentation to include project labels


## Updated docs pages

- GitLab Exporter Example Port App Config (`/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_port_app_config`)  
- GitLab Exporter Example Repository Blueprint (`/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_repository_blueprint`) 
