### PR TITLE
PORT-12439 Updated mapping examples for jira issues

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/examples/_jira_example_issue_configuration.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/examples/_jira_example_issue_configuration.mdx
@@ -14,16 +14,16 @@
           status: .fields.status.name
           issueType: .fields.issuetype.name
           components: .fields.components
-          creator: .fields.creator.emailAddress
+          creator: .fields.creator.emailAddress // empty
           priority: .fields.priority.name
           labels: .fields.labels
           created: .fields.created
           updated: .fields.updated
-          resolutionDate: .fields.resolutiondate
+          resolutionDate: .fields.resolutiondate // empty
         relations:
           project: .fields.project.key
-          parentIssue: .fields.parent.key
+          parentIssue: .fields.parent.key // empty
           subtasks: .fields.subtasks | map(.key)
-          assignee: .fields.assignee.accountId
+          assignee: .fields.assignee.accountId // empty
           reporter: .fields.reporter.accountId
 ```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/examples/_jira_example_issue_configuration.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/examples/_jira_example_issue_configuration.mdx
@@ -14,16 +14,16 @@
           status: .fields.status.name
           issueType: .fields.issuetype.name
           components: .fields.components
-          creator: .fields.creator.emailAddress // empty
+          creator: .fields.creator.emailAddress
           priority: .fields.priority.name
           labels: .fields.labels
           created: .fields.created
           updated: .fields.updated
-          resolutionDate: .fields.resolutiondate // empty
+          resolutionDate: .fields.resolutiondate
         relations:
           project: .fields.project.key
-          parentIssue: .fields.parent.key // empty
+          parentIssue: .fields.parent.key
           subtasks: .fields.subtasks | map(.key)
-          assignee: .fields.assignee.accountId // empty
+          assignee: .fields.assignee.accountId
           reporter: .fields.reporter.accountId
 ```

--- a/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/jira.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/jira.md
@@ -739,17 +739,17 @@ resources:
             status: .fields.status.name
             issueType: .fields.issuetype.name
             components: .fields.components
-            assignee: .fields.assignee.emailAddress // empty
+            assignee: .fields.assignee.emailAddress
             reporter: .fields.reporter.emailAddress
-            creator: .fields.creator.emailAddress // empty
+            creator: .fields.creator.emailAddress
             priority: .fields.priority.name
             // highlight-next-line
-            sprint: .fields.customfield_11111[-1].name // empty
+            sprint: .fields.customfield_11111[-1].name
             created: .fields.created
             updated: .fields.updated
           relations:
             project: .fields.project.key
-            parentIssue: .fields.parent.key // empty
+            parentIssue: .fields.parent.key
             subtasks: .fields.subtasks | map(.key)
 ```
 
@@ -788,17 +788,17 @@ resources:
             status: .fields.status.name
             issueType: .fields.issuetype.name
             components: .fields.components
-            assignee: .fields.assignee.emailAddress // empty
+            assignee: .fields.assignee.emailAddress
             reporter: .fields.reporter.emailAddress
-            creator: .fields.creator.emailAddress // empty
+            creator: .fields.creator.emailAddress
             priority: .fields.priority.name
             // highlight-next-line
-            sprint: .fields.customfield_11111 | sort_by(.id) | .[-1].name // empty
+            sprint: .fields.customfield_11111 | sort_by(.id) | .[-1].name
             created: .fields.created
             updated: .fields.updated
           relations:
             project: .fields.project.key
-            parentIssue: .fields.parent.key // empty
+            parentIssue: .fields.parent.key
             subtasks: .fields.subtasks | map(.key)
 ```
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/jira.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/project-management/jira/jira.md
@@ -739,17 +739,17 @@ resources:
             status: .fields.status.name
             issueType: .fields.issuetype.name
             components: .fields.components
-            assignee: .fields.assignee.emailAddress
+            assignee: .fields.assignee.emailAddress // empty
             reporter: .fields.reporter.emailAddress
-            creator: .fields.creator.emailAddress
+            creator: .fields.creator.emailAddress // empty
             priority: .fields.priority.name
             // highlight-next-line
-            sprint: .fields.customfield_11111[-1].name // ""
+            sprint: .fields.customfield_11111[-1].name // empty
             created: .fields.created
             updated: .fields.updated
           relations:
             project: .fields.project.key
-            parentIssue: .fields.parent.key
+            parentIssue: .fields.parent.key // empty
             subtasks: .fields.subtasks | map(.key)
 ```
 
@@ -788,17 +788,17 @@ resources:
             status: .fields.status.name
             issueType: .fields.issuetype.name
             components: .fields.components
-            assignee: .fields.assignee.emailAddress
+            assignee: .fields.assignee.emailAddress // empty
             reporter: .fields.reporter.emailAddress
-            creator: .fields.creator.emailAddress
+            creator: .fields.creator.emailAddress // empty
             priority: .fields.priority.name
             // highlight-next-line
-            sprint: .fields.customfield_11111 | sort_by(.id) | .[-1].name // ""
+            sprint: .fields.customfield_11111 | sort_by(.id) | .[-1].name // empty
             created: .fields.created
             updated: .fields.updated
           relations:
             project: .fields.project.key
-            parentIssue: .fields.parent.key
+            parentIssue: .fields.parent.key // empty
             subtasks: .fields.subtasks | map(.key)
 ```
 


### PR DESCRIPTION
# Description

Updated sample mappings for Jira issue to use `empty` when key is not present in JSON instead of `""`

## Updated docs pages

Please also include the path for the updated docs

- Blueprint (`build-your-software-catalog/sync-data-to-catalog/project-management/jira`)