### PR TITLE
Adds deprecation date to sonarqube projects kind

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
@@ -817,7 +817,7 @@ To remedy this, we have switched to the globally available API for projects inst
 
 ### Changes to the SonarQube integration
 
-- The `project` kind is deprecated in support for the `projects_ga` kind.
+- The `project` kind is deprecated in support for the `projects_ga` kind. *Deprecation effective: 2024-02-23*
 
 - Since `tags` property is only available with the internal API, the tags property will read `null` for existing users.
 


### PR DESCRIPTION
# Description  

This update includes a date in the deprecation of sonarqube project kind  

## Updated Documentation Pages  

The following documentation pages have been updated:  
- **SonarQube Integration**: `/software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md`  

