### PR TITLE
Port 12664 Correct all the service blueprint identifiers for the git integrations

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_port_app_config.mdx
@@ -28,7 +28,7 @@ resources:
         mappings:
           identifier: "\(.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.name | ascii_downcase | gsub("[ ();]"; ""))"
           title: .name
-          blueprint: '"service"'
+          blueprint: '"azureDevopsRepository"'
           properties:
             url: .url
             readme: file://README.md
@@ -41,7 +41,7 @@ resources:
       entity:
         mappings:
           identifier: '.__repository.project.name + "/" + .__repository.name | gsub(" "; "")'
-          blueprint: '"service"'
+          blueprint: '"azureDevopsRepository"'
           properties:
             minimumApproverCount: .settings.minimumApproverCount
   - kind: repository-policy
@@ -51,7 +51,7 @@ resources:
       entity:
         mappings:
           identifier: '.__repository.project.name + "/" + .__repository.name | gsub(" "; "")'
-          blueprint: '"service"'
+          blueprint: '"azureDevopsRepository"'
           properties:
             workItemLinking: .isEnabled and .isBlocking
   - kind: pull-request
@@ -78,7 +78,7 @@ resources:
               (((($closedTimestamp - $createdTimestamp) / 3600) * 100 | floor) / 100)
               else null end)
           relations:
-            service: '.repository.project.name + "/" + .repository.name | gsub(" "; "")'
+            repository: '.repository.project.name + "/" + .repository.name | gsub(" "; "")'
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_pull_request_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_pull_request_blueprint.mdx
@@ -55,9 +55,9 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "azureDevopsRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_repository_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_repository_blueprint.mdx
@@ -3,8 +3,8 @@
 
 ```json showLineNumbers
   {
-    "identifier": "service",
-    "title": "Service",
+    "identifier": "azureDevopsRepository",
+    "title": "Repository",
     "icon": "AzureDevops",
     "schema": {
       "properties": {

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops.md
@@ -334,7 +334,7 @@ The combination of the sample payload and the Ocean configuration generates the 
 {
   "identifier": "PortIntegration/final_project_to_project_test",
   "title": "final_project_to_project_test",
-  "blueprint": "service",
+  "blueprint": "azureDevopsRepository",
   "properties": {
     "url": "[REDACTED]/fd029361-7854-4cdd-8ace-bb033fca399c/_apis/git/repositories/43c319c8-5adc-41f8-8486-745fe2130cd6",
     "readme": "<README.md Content>",

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-teams/_azuredevops_exporter_example_teams_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-teams/_azuredevops_exporter_example_teams_port_app_config.mdx
@@ -28,7 +28,7 @@ resources:
         mappings:
           identifier: '.project.name + "/" + .name | gsub(" "; "")'
           title: .name
-          blueprint: '"service"'
+          blueprint: '"azureDevopsRepository"'
           properties:
             url: .url
             readme: file://README.md
@@ -41,7 +41,7 @@ resources:
       entity:
         mappings:
           identifier: '.__repository.project.name + "/" + .__repository.name | gsub(" "; "")'
-          blueprint: '"service"'
+          blueprint: '"azureDevopsRepository"'
           properties:
             minimumApproverCount: .settings.minimumApproverCount
   - kind: repository-policy
@@ -51,7 +51,7 @@ resources:
       entity:
         mappings:
           identifier: '.__repository.project.name + "/" + .__repository.name | gsub(" "; "")'
-          blueprint: '"service"'
+          blueprint: '"azureDevopsRepository"'
           properties:
             workItemLinking: .isEnabled and .isBlocking
   - kind: team

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md
@@ -39,7 +39,7 @@ To do so, we will use the `file://` prefix with the path of the file to tell the
         mappings:
           identifier: .project.name + "/" + .name
           title: .name
-          blueprint: '"service"'
+          blueprint: '"azureDevopsRepository"'
           properties:
             url: .url
             // highlight-next-line

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/_bitbucket_exporter_example_monorepo_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/_bitbucket_exporter_example_monorepo_port_app_config.mdx
@@ -16,7 +16,7 @@ resources:
       entity:
         mappings:
           identifier: .folder.name
-          blueprint: '"service"'
+          blueprint: '"bitbucketRepository"'
           properties:
             url: .repo.links.html.href + "/src/" + .repo.mainbranch.name + "/" + .folder.path
             readme: file://README.md

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/_bitbucket_exporter_example_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/_bitbucket_exporter_example_port_app_config.mdx
@@ -10,9 +10,9 @@ resources:
     port:
       entity:
         mappings:
-          identifier: ".name" # The Entity identifier will be the service (repository) name. After the Entity is created, the exporter will send `PATCH` requests to update this microservice within Port.
+          identifier: ".name" # The Entity identifier will be the repository name. After the Entity is created, the exporter will send `PATCH` requests to update this microservice within Port.
           title: ".name"
-          blueprint: '"service"'
+          blueprint: '"bitbucketRepository"'
           properties:
             readme: file://README.md # fetching the README.md file that is within the root folder of the repository and ingesting its contents as a markdown property
             url: ".links.html.href"
@@ -35,7 +35,7 @@ resources:
             updatedAt: ".updated_on"
             link: ".links.html.href"
           relations:
-            service: ".destination.repository.name"
+            repository: ".destination.repository.name"
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/_bitbucket_exporter_example_pull_request_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/_bitbucket_exporter_example_pull_request_blueprint.mdx
@@ -59,9 +59,9 @@
   },
   "aggregationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "bitbucketRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/_bitbucket_exporter_example_repository_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/_bitbucket_exporter_example_repository_blueprint.mdx
@@ -1,10 +1,10 @@
 <details>
-<summary>Service blueprint</summary>
+<summary>Repository blueprint</summary>
 
 ```json showLineNumbers
 {
-  "identifier": "service",
-  "title": "Service",
+  "identifier": "bitbucketRepository",
+  "title": "Repository",
   "icon": "Microservice",
   "schema": {
     "properties": {
@@ -14,7 +14,7 @@
         "format": "markdown"
       },
       "url": {
-        "title": "Service URL",
+        "title": "Repository URL",
         "type": "string",
         "format": "url"
       },

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/_bitbucket_exporter_supported_resources.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/_bitbucket_exporter_supported_resources.mdx
@@ -1,4 +1,4 @@
-- [`service (repository)`](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-get)
+- [`repository`](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-get)
 - [`pull-request`](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-get)
 - [`folder`](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-source/#api-repositories-workspace-repo-slug-src-commit-path-get)
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/bitbucket.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/bitbucket.md
@@ -102,7 +102,7 @@ The app allows you to ingest a variety of objects resources provided by the Bitb
 
 The Bitbucket app uses a YAML configuration file to describe the ETL process to load data into the developer portal. The approach reflects a golden middle between an overly opinionated Git visualization that might not work for everyone and a too-broad approach that could introduce unneeded complexity into the developer portal.
 
-After installing the app, Port will automatically create a `service` blueprint in your catalog (representing a BitBucket repository), along with a default YAML configuration file that defines where the data fetched from BitBucket's API should go in the blueprint.
+After installing the app, Port will automatically create a `repository` blueprint in your catalog (representing a BitBucket repository), along with a default YAML configuration file that defines where the data fetched from BitBucket's API should go in the blueprint.
 
 
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/examples.md
@@ -33,7 +33,7 @@ After creating the blueprints and committing the `port-app-config.yml` file to y
 
 ## Mapping repositories and monorepos
 
-In the following example you will ingest your Bitbucket repositories and their folders to Port. By following this example you can map your different services, packages and libraries from your monorepo into separate entities in Port. you may use the following Port blueprint definitions and `port-app-config.yml`:
+In the following example you will ingest your Bitbucket repositories and their folders to Port. By following this example you can map your different repositories, packages and libraries from your monorepo into separate entities in Port. you may use the following Port blueprint definitions and `port-app-config.yml`:
 
 <MicroserviceBlueprint/>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_port_app_config.mdx
@@ -12,7 +12,7 @@ resources:
         mappings:
           identifier: ".name" # The Entity identifier will be the repository name.
           title: ".name"
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md # fetching the README.md file that is within the root folder of the repository and ingesting its contents as a markdown property
             url: .html_url
@@ -46,7 +46,7 @@ resources:
                 (((($mergedTimestamp - $createdTimestamp) / 3600) * 100 | floor) / 100) end)
 
           relations:
-            service: .head.repo.name
+            repository: .head.repo.name
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_pull_request_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_pull_request_blueprint.mdx
@@ -71,9 +71,9 @@
     }
   },
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "githubRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_repository_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_repository_blueprint.mdx
@@ -1,10 +1,10 @@
 <details>
-<summary>Service blueprint</summary>
+<summary>Repository blueprint</summary>
 
 ```json showLineNumbers
 {
-  "identifier": "service",
-  "title": "Service",
+  "identifier": "githubRepository",
+  "title": "Repository",
   "icon": "Microservice",
   "schema": {
     "properties": {
@@ -14,7 +14,7 @@
         "format": "markdown"
       },
       "url": {
-        "title": "Service URL",
+        "title": "Repository URL",
         "type": "string",
         "format": "url"
       },

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_git_exporter_example_branch_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_git_exporter_example_branch_blueprint.mdx
@@ -32,7 +32,7 @@
   "relations": {
     "repository": {
       "title": "Repository",
-      "target": "service",
+      "target": "githubRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_git_exporter_example_branch_protection_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_git_exporter_example_branch_protection_blueprint.mdx
@@ -100,7 +100,7 @@
   "relations": {
     "repository": {
       "title": "Repository",
-      "target": "service",
+      "target": "githubRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_git_exporter_example_last_contributor_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_git_exporter_example_last_contributor_blueprint.mdx
@@ -1,10 +1,10 @@
 <details>
-<summary>Service blueprint</summary>
+<summary>Repository blueprint</summary>
 
 ```json showLineNumbers
 {
-  "identifier": "service",
-  "title": "Service",
+  "identifier": "githubRepository",
+  "title": "Repository",
   "icon": "Microservice",
   "schema": {
     "properties": {
@@ -14,7 +14,7 @@
         "format": "markdown"
       },
       "url": {
-        "title": "Service URL",
+        "title": "Repository URL",
         "type": "string",
         "format": "url"
       },

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_github_exporter_example_branch_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_github_exporter_example_branch_port_app_config.mdx
@@ -11,7 +11,7 @@ resources:
         mappings:
           identifier: .name
           title: .name
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_github_exporter_example_branch_protection_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_github_exporter_example_branch_protection_port_app_config.mdx
@@ -11,7 +11,7 @@ resources:
         mappings:
           identifier: .name
           title: .name
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_github_exporter_example_last_contributor_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-branch/_github_exporter_example_last_contributor_port_app_config.mdx
@@ -11,7 +11,7 @@ resources:
         mappings:
           identifier: .name
           title: .name
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url
@@ -23,7 +23,7 @@ resources:
       entity:
         mappings:
           identifier: .repository.name
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             last_contributor: .branch.commit.commit.author.email
             last_push: .branch.commit.commit.committer.date

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-deployments-environments/_github_exporter_example_deployments_and_environments_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-deployments-environments/_github_exporter_example_deployments_and_environments_port_app_config.mdx
@@ -13,7 +13,7 @@ resources:
         mappings:
           identifier: ".name" # The Entity identifier will be the repository name.
           title: ".name"
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-deployments-environments/_github_exporter_example_environment_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-deployments-environments/_github_exporter_example_environment_blueprint.mdx
@@ -39,8 +39,8 @@
   "mirrorProperties": {},
   "calculationProperties": {},
   "relations": {
-    "service": {
-      "target": "service",
+    "repository": {
+      "target": "githubRepository",
       "required": true,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-issue/_git_exporter_example_issue_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-issue/_git_exporter_example_issue_blueprint.mdx
@@ -64,8 +64,8 @@
   "mirrorProperties": {},
   "calculationProperties": {},
   "relations": {
-    "service": {
-      "target": "service",
+    "repository": {
+      "target": "githubRepository",
       "required": true,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-issue/_github_exporter_example_issue_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-issue/_github_exporter_example_issue_port_app_config.mdx
@@ -12,7 +12,7 @@ resources:
         mappings:
           identifier: ".name" # The Entity identifier will be the repository name.
           title: ".name"
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url
@@ -38,7 +38,7 @@ resources:
             issueNumber: ".number"
             link: ".html_url"
           relations:
-            service: ".repo"
+            repository: ".repo"
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-monorepo/_github_exporter_example_monorepo_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-monorepo/_github_exporter_example_monorepo_port_app_config.mdx
@@ -17,7 +17,7 @@ resources:
         mappings:
           identifier: ".folder.name"
           title: ".folder.name"
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             url: .repo.html_url + "/tree/" + .repo.default_branch  + "/" + .folder.path
             readme: file://README.md

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-admins/_github_export_example_repository_with_admins_relation_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-admins/_github_export_example_repository_with_admins_relation_blueprint.mdx
@@ -1,10 +1,10 @@
 <details>
-<summary>Service blueprint</summary>
+<summary>Repository blueprint</summary>
 
 ```json showLineNumbers
 {
-  "identifier": "service",
-  "title": "Service",
+  "identifier": "githubRepository",
+  "title": "Repository",
   "icon": "Microservice",
   "schema": {
     "properties": {
@@ -14,7 +14,7 @@
         "format": "markdown"
       },
       "url": {
-        "title": "Service URL",
+        "title": "Repository URL",
         "type": "string",
         "format": "url"
       }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-admins/_github_exporter_example_admins_users_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-admins/_github_exporter_example_admins_users_port_app_config.mdx
@@ -14,7 +14,7 @@ resources:
         mappings:
           identifier: .name
           title: .name
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-alerts/_github_exporter_example_codeScan_alert_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-alerts/_github_exporter_example_codeScan_alert_blueprint.mdx
@@ -35,9 +35,9 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "githubRepository",
       "required": false,
       "many": true
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-alerts/_github_exporter_example_dependabot_alert_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-alerts/_github_exporter_example_dependabot_alert_blueprint.mdx
@@ -89,9 +89,9 @@
   "mirrorProperties": {},
   "calculationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "githubRepository",
       "required": true,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-alerts/_github_exporter_example_repo_dependabot_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-alerts/_github_exporter_example_repo_dependabot_port_app_config.mdx
@@ -12,7 +12,7 @@ resources:
         mappings:
           identifier: .name
           title: .name
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url
@@ -40,7 +40,7 @@ resources:
             alertCreatedAt: .created_at
             alertUpdatedAt: .updated_at
           relations:
-            service: .repo.name
+            repository: .repo.name
   - kind: code-scanning-alerts
     selector:
       query: "true"
@@ -57,7 +57,7 @@ resources:
             description: .rule.description
             url: .html_url
           relations:
-            service: .repo
+            repository: .repo
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-folders/_github_exporter_example_folder_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-folders/_github_exporter_example_folder_blueprint.mdx
@@ -24,9 +24,9 @@
   "mirrorProperties": {},
   "calculationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "githubRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-folders/_github_exporter_example_pull_request_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-folders/_github_exporter_example_pull_request_blueprint.mdx
@@ -55,9 +55,9 @@
   "mirrorProperties": {},
   "calculationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "githubRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-folders/_github_exporter_example_repo_folders_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-folders/_github_exporter_example_repo_folders_port_app_config.mdx
@@ -12,7 +12,7 @@ resources:
         mappings:
           identifier: .name
           title: .name
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url
@@ -37,7 +37,7 @@ resources:
             prNumber: .id
             link: .html_url
           relations:
-            service: .head.repo.name
+            repository: .head.repo.name
   - kind: folder
     selector:
       query: "true"
@@ -58,7 +58,7 @@ resources:
               .folder.path
             readme: file://README.md
           relations:
-            service: .repo.name
+            repository: .repo.name
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-release-tag/_github_exporter_example_release_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-release-tag/_github_exporter_example_release_blueprint.mdx
@@ -29,9 +29,9 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "githubRepository",
       "required": false,
       "many": false
     },

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-release-tag/_github_exporter_example_release_tag_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-release-tag/_github_exporter_example_release_tag_port_app_config.mdx
@@ -12,7 +12,7 @@ resources:
         mappings:
           identifier: ".name" # The Entity identifier will be the repository name.
           title: ".name"
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url
@@ -32,7 +32,7 @@ resources:
             release_creation_time: .release.created_at
           relations:
             tag: .release.tag_name
-            service: .repo.name
+            repository: .repo.name
   - kind: tag
     selector:
       query: 'true'
@@ -45,7 +45,7 @@ resources:
           properties:
             commit_sha: .commit.sha
           relations:
-            service: .repo.name
+            repository: .repo.name
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-release-tag/_github_exporter_example_tag_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-release-tag/_github_exporter_example_tag_blueprint.mdx
@@ -21,9 +21,9 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "githubRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-teams/_github_export_example_repository_with_teams_relation_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-teams/_github_export_example_repository_with_teams_relation_blueprint.mdx
@@ -1,10 +1,10 @@
 <details>
-<summary>Service blueprint</summary>
+<summary>Repository blueprint</summary>
 
 ```json showLineNumbers
 {
-  "identifier": "service",
-  "title": "Service",
+  "identifier": "githubRepository",
+  "title": "Repository",
   "icon": "Microservice",
   "schema": {
     "properties": {
@@ -14,7 +14,7 @@
         "format": "markdown"
       },
       "url": {
-        "title": "Service URL",
+        "title": "Repository URL",
         "type": "string",
         "format": "url"
       },

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-teams/_github_exporter_example_repository_with_teams_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-repository-teams/_github_exporter_example_repository_with_teams_port_app_config.mdx
@@ -30,7 +30,7 @@ resources:
         mappings:
           identifier: .name
           title: .name
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-workflow-workflowrun/_git_exporter_example_workflow_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-workflow-workflowrun/_git_exporter_example_workflow_blueprint.mdx
@@ -53,9 +53,9 @@
   "mirrorProperties": {},
   "calculationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "githubRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-workflow-workflowrun/_github_exporter_example_wf_wfr_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/example-workflow-workflowrun/_github_exporter_example_wf_wfr_port_app_config.mdx
@@ -12,7 +12,7 @@ resources:
         mappings:
           identifier: ".name" # The Entity identifier will be the repository name.
           title: ".name"
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             readme: file://README.md
             url: .html_url
@@ -33,7 +33,7 @@ resources:
             updatedAt: ".updated_at"
             link: ".html_url"
           relations:
-            service: ".repo"
+            repository: ".repo"
   - kind: workflow-run
     selector:
       query: ".status != 'completed'" # JQ boolean query. If evaluated to false - skip syncing the object.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/github.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/github.md
@@ -109,7 +109,7 @@ The app allows you to ingest a variety of objects resources provided by the GitH
 
 The GitHub app uses a YAML configuration file to describe the ETL process to load data into the developer portal. The approach reflects a golden middle between an overly opinionated Git visualization that might not work for everyone and a too-broad approach that could introduce unneeded complexity into the developer portal.
 
-After installing the app, Port will automatically create a `service` blueprint in your catalog (representing a GitHub repository), along with a default YAML configuration file that defines where the data fetched from Github's API should go in the blueprint.
+After installing the app, Port will automatically create a `repository` blueprint in your catalog (representing a GitHub repository), along with a default YAML configuration file that defines where the data fetched from Github's API should go in the blueprint.
 
 ### Ingest files from your repositories
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/self-hosted-installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/self-hosted-installation.md
@@ -122,7 +122,7 @@ docker run \
 
 ## Health check route
 
-A health check is a route that is used to check the health of a service. It is a means to ensure that the service is running properly and can perform its intended function.
+A health check is a route that is used to check the health of a repository. It is a means to ensure that the service is running properly and can perform its intended function.
 
 Our GitHub App image exposes a health check route at `https://host:port/health` to monitor its status.
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_merge_request_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_merge_request_blueprint.mdx
@@ -66,9 +66,9 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "gitlabRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_port_app_config.mdx
@@ -13,7 +13,7 @@ resources:
         mappings:
           identifier: .path_with_namespace | gsub(" "; "")
           title: .name
-          blueprint: '"service"'
+          blueprint: '"gitlabRepository"'
           properties:
             url: .web_url
             readme: file://README.md
@@ -48,7 +48,7 @@ resources:
                 (((($mergedTimestamp - $createdTimestamp) / 3600) * 100 | floor) / 100) end)
             reviewers: .reviewers | map(.name)
           relations:
-            service: .references.full | gsub("!.+"; "")
+            repository: .references.full | gsub("!.+"; "")
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_repository_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_gitlab_exporter_example_repository_blueprint.mdx
@@ -1,10 +1,10 @@
 <details>
-<summary>Service blueprint</summary>
+<summary>Repository blueprint</summary>
 
 ```json showLineNumbers
 {
-  "identifier": "service",
-  "title": "Service",
+  "identifier": "gitlabRepository",
+  "title": "Repository",
   "icon": "Microservice",
   "schema": {
     "properties": {

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-groups-subgroups/_gitlab_exporter_example_group_repository_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-groups-subgroups/_gitlab_exporter_example_group_repository_port_app_config.mdx
@@ -28,7 +28,7 @@ resources:
         mappings:
           identifier: .path_with_namespace | gsub(" "; "")
           title: .name
-          blueprint: '"service"'
+          blueprint: '"gitlabRepository"'
           properties:
             url: .web_url
             readme: file://README.md

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-groups-subgroups/_gitlab_exporter_example_repository_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-groups-subgroups/_gitlab_exporter_example_repository_blueprint.mdx
@@ -1,10 +1,10 @@
 <details>
-<summary>Service blueprint</summary>
+<summary>Repository blueprint</summary>
 
 ```json showLineNumbers
 {
-  "identifier": "service",
-  "title": "Service",
+  "identifier": "gitlabRepository",
+  "title": "Repository",
   "icon": "Microservice",
   "schema": {
     "properties": {

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-issue/_git_exporter_example_issue_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-issue/_git_exporter_example_issue_blueprint.mdx
@@ -57,9 +57,9 @@
   },
   "calculationProperties": {},
   "relations": {
-    "service": {
-      "target": "service",
-      "title": "Service",
+    "repository": {
+      "title": "Repository",
+      "target": "gitlabRepository",
       "required": true,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-issue/_gitlab_exporter_example_issue_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-issue/_gitlab_exporter_example_issue_port_app_config.mdx
@@ -12,7 +12,7 @@ resources:
         mappings:
           identifier: .path_with_namespace | gsub(" "; "")
           title: .name
-          blueprint: '"service"'
+          blueprint: '"gitlabRepository"'
           properties:
             url: .web_url
             description: .description
@@ -39,7 +39,7 @@ resources:
             link: .web_url
             labels: "[.labels[]]"
           relations:
-            service: .references.full | gsub("#.+"; "")
+            repository: .references.full | gsub("#.+"; "")
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-pipeline-job/_git_exporter_example_pipeline_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-pipeline-job/_git_exporter_example_pipeline_blueprint.mdx
@@ -70,9 +70,9 @@
   "mirrorProperties": {},
   "calculationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "gitlabRepository",
       "required": true,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-pipeline-job/_gitlab_exporter_example_pipeline_job_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-pipeline-job/_gitlab_exporter_example_pipeline_job_port_app_config.mdx
@@ -12,7 +12,7 @@ resources:
         mappings:
           identifier: .path_with_namespace | gsub(" "; "")
           title: .name
-          blueprint: '"service"'
+          blueprint: '"gitlabRepository"'
           properties:
             url: .web_url
             description: .description
@@ -37,7 +37,7 @@ resources:
             description: .description
             link: .web_url
           relations:
-            service: .__project.path_with_namespace | gsub(" "; "")
+            repository: .__project.path_with_namespace | gsub(" "; "")
   - kind: job
     selector:
       query: "true"

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-projects-members/_gitlab_exporter_example_project_member_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-projects-members/_gitlab_exporter_example_project_member_blueprint.mdx
@@ -1,10 +1,10 @@
 <details>
-<summary>Service blueprint</summary>
+<summary>Repository blueprint</summary>
 
 ```json showLineNumbers
 {
-  "identifier": "service",
-  "title": "Service",
+  "identifier": "gitlabRepository",
+  "title": "Repository",
   "icon": "Microservice",
   "schema": {
     "properties": {

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-projects-members/_gitlab_exporter_example_project_member_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-projects-members/_gitlab_exporter_example_project_member_port_app_config.mdx
@@ -31,7 +31,7 @@ resources:
         mappings:
           identifier: .path_with_namespace | gsub(" "; "")
           title: .name
-          blueprint: '"service"'
+          blueprint: '"gitlabRepository"'
           properties:
             url: .web_url
             readme: file://README.md

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-repository-folders/_gitlab_exporter_example_folder_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-repository-folders/_gitlab_exporter_example_folder_blueprint.mdx
@@ -24,9 +24,9 @@
   "mirrorProperties": {},
   "calculationProperties": {},
   "relations": {
-    "service": {
-      "title": "Service",
-      "target": "service",
+    "repository": {
+      "title": "Repository",
+      "target": "gitlabRepository",
       "required": false,
       "many": false
     }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-repository-folders/_gitlab_exporter_example_repo_folders_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/example-repository-folders/_gitlab_exporter_example_repo_folders_port_app_config.mdx
@@ -12,7 +12,7 @@ resources:
         mappings:
           identifier: .name
           title: .name
-          blueprint: '"service"'
+          blueprint: '"gitlabRepository"'
           properties:
             readme: file://README.md
             url: .web_url
@@ -37,7 +37,7 @@ resources:
               .folder.path
             readme: file://README.md
           relations:
-            service: .repo.name
+            repository: .repo.name
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/mapping_extensions.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/mapping_extensions.md
@@ -39,7 +39,7 @@ To do so, we will use the `file://` prefix with the path of the file to tell the
         mappings:
           identifier: .path_with_namespace | gsub(" "; "")
           title: .name
-          blueprint: '"service"'
+          blueprint: '"gitlabRepository"'
           properties:
             url: .web_url
             // highlight-next-line
@@ -90,7 +90,7 @@ This means that any search query supported by the GitLab Search API can be used 
         mappings:
           identifier: .path_with_namespace | gsub(" "; "")
           title: .name
-          blueprint: '"service"'
+          blueprint: '"gitlabRepository"'
           properties:
             url: .web_link
             description: .description

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/working-with-monorepos.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/working-with-monorepos.md
@@ -52,7 +52,7 @@ resources:
         mappings:
           identifier: ".folder.name"
           title: ".folder.name"
-          blueprint: '"service"'
+          blueprint: '"githubRepository"'
           properties:
             url: .repo.html_url + "/tree/" + .repo.default_branch  + "/" + .folder.path
             readme: file://README.md
@@ -79,7 +79,7 @@ resources:
         mappings:
           identifier: .folder.name
           title: .folder.name
-          blueprint: '"service"'
+          blueprint: '"gitlabRepository"'
           properties:
             url: >-
               .repo.web_url + "/tree/" + .repo.default_branch  + "/" +
@@ -108,7 +108,7 @@ resources:
       entity:
         mappings:
           identifier: .folder.name
-          blueprint: '"service"'
+          blueprint: '"bitbucketRepository"'
           properties:
             url: .repo.links.html.href + "/src/" + .repo.mainbranch.name + "/" + .folder.path
             readme: file://README.md


### PR DESCRIPTION
# Description

Corrected the repository blueprint identifier used for all the Git integrations to use the new identifiers because of the new onboarding change.


## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- Git (`/build-your-software-catalog/sync-data-to-catalog/git/`)
- Github (`/build-your-software-catalog/sync-data-to-catalog/git/github`)
- Gitlab (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab`)
- AzureDevOps (`/build-your-software-catalog/sync-data-to-catalog/git/azure-devops`)
- BitBucket (`/build-your-software-catalog/sync-data-to-catalog/git/bitbucket`)
- MonoRepos (`/build-your-software-catalog/sync-data-to-catalog/git/working-with-monorepos`)
