### PR TITLE
Map Kafka members mapping to an array of client id strings

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/event-processing/kafka.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/event-processing/kafka.md
@@ -642,7 +642,7 @@ resources:
           blueprint: '"kafkaConsumerGroup"'
           properties:
             state: .state
-            members: .members
+            members: .members | map(.client_id)
             coordinator: .coordinator.id
             partition_assignor: .partition_assignor
             is_simple_consumer_group: .is_simple_consumer_group


### PR DESCRIPTION
### Description  

The Kafka consumer group blueprint currently expects members to be an array of strings. However, in the mapping configuration, the entire members object was being mapped, resulting in an error: `"members/0" must be string`. This occurs when users attempt to set up the integration using the mapping and configuration provided in the documentation.  

### Updated Docs Pages  

The updated documentation can be found at the following path:  
- **Kafka Integration**: `build-your-software-catalog/sync-data-to-catalog/event-processing/kafka`  

This update ensures the configuration and mapping align correctly with the blueprint requirements, resolving the issue for users.