### PR TITLE
Fix KICS mapping configuration

### DIFF
--- a/docs/guides/all/ingest-checkmarx-kics-scan-into-your-catalog.md
+++ b/docs/guides/all/ingest-checkmarx-kics-scan-into-your-catalog.md
@@ -92,20 +92,23 @@ resources:
       files:
         - path: '**/results.json'
     port:
-      itemsToParse: '[.file.content[] | select(.Vulnerabilities != null) as $input | .Vulnerabilities[] | {VulnerabilityID, PkgName, InstalledVersion, FixedVersion, Title, Description, Severity, References, PrimaryURL, DataSource, Target: $input.Target}]'
+      itemsToParse: >-
+        [.file.url as $url | .file.content.queries[] | {$url, query_id,
+        query_name, severity, platform, files, cloud_provider, description,
+        category}]
       entity:
         mappings:
-          identifier: .item.VulnerabilityID
-          title: .item.Title
-          blueprint: '"trivyVulnerability"'
+          identifier: .item.query_id
+          title: .item.query_name
+          blueprint: '"kicsScan"'
           properties:
-            version: .item.InstalledVersion
-            package_name: .item.PkgName
-            primaryUrl: .item.PrimaryURL
-            description: .item.Description
-            target: .item.Target
-            severity: .item.Severity
-            data_source: .item.DataSource
+            category: .item.category
+            cloud_provider: .item.cloud_provider
+            description: .item.description
+            files: .item.files
+            severity: .item.severity
+            platform: .item.platform
+            url: .item.url
 ```
 
 </details>


### PR DESCRIPTION
The KICS mapping was incorrect - looked like it was copied from Trivy. This config properly maps the fields from KICS results.json file to the blueprint in the guide.

# Description

Reviewed KICS instructions earlier today with Checkmarx team and KICS PM and we noticed some issues in the mapping config. As part of becoming "official" integration with Checkmarx we need to get the basic integration working so I've edited it to correct mappings.

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
