### PR TITLE
PORT-12907 Removed publish key on trigger data dog incident SSA

### DIFF
--- a/docs/guides/all/trigger-datadog-incident.md
+++ b/docs/guides/all/trigger-datadog-incident.md
@@ -335,8 +335,7 @@ Make sure to replace `<GITHUB_ORG>` and `<GITHUB_REPO>` with your GitHub organiz
     },
     "reportWorkflowStatus": true
   },
-  "requiredApproval": false,
-  "publish": true
+  "requiredApproval": false
 }
 ```
 </details>


### PR DESCRIPTION

# Description

Removed redundant publish field from Datadog incident trigger configuration


## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- Triggar DataDog Incident (`/guides/all/trigger-datadog-incident`)
