### PR TITLE
PORT-13008 | BUG Fix Github to service relation identifier

### DIFF
--- a/docs/guides/all/scaffold-a-new-service.md
+++ b/docs/guides/all/scaffold-a-new-service.md
@@ -370,7 +370,7 @@ If the GitHub organization which will house your workflow is not the same as the
               blueprint: "service"
               relations: |
                 {
-                  "githubRepository": "${{ inputs.service_name }}"
+                  "repository": "${{ inputs.service_name }}"
                 }
     
           - name: Create a log message


### PR DESCRIPTION
# Description

Fix: update blueprint identifier from `githubRepository` to `repository`

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- Scaffolder (`/guides/all/scaffold-a-new-service`)
