### PR TITLE
added new tad for create missing related entities in bitbucket

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/advanced.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/advanced.md
@@ -45,6 +45,16 @@ The `enableMergeEntity` parameter specifies whether to use the [create/update](/
 
 </TabItem>
 
+<TabItem value="createMissingRelatedEntities" label="Create missing related entities">
+
+The `createMissingRelatedEntities` parameter is used to enable the creation of missing related Port entities automatically in cases where the target related entity does not exist in the software catalog yet.
+
+- Default value: `true` to allow the Bitbucket app to create barebones related entities, in case those related entities do not exist in the software catalog.
+- Use case: use `false` if you do not want this default behavior (do not create missing related entities).
+
+</TabItem>
+
+
 </Tabs>
 
 All of the advanced configurations listed below can be added to the [`port-app-config.yml`](./bitbucket.md#port-app-configyml-file) file.


### PR DESCRIPTION
# Description

we added support in bitbucket app to create missing related entities
## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
