### PR TITLE
PORT-13086 | Fix Service - Gitlab relationship Identifier in scaffold new guide and other places in the documentation

### DIFF
--- a/docs/guides/all/scaffold-a-new-service.md
+++ b/docs/guides/all/scaffold-a-new-service.md
@@ -625,7 +625,7 @@ create-service:
       curl --location --request POST "https://api.getport.io/v1/blueprints/service/entities?upsert=true&run_id=$RUN_ID&create_missing_related_entities=true" \
         --header "Authorization: Bearer $ACCESS_TOKEN" \
         --header "Content-Type: application/json" \
-        -d '{"identifier": "'"$SERVICE_NAME"'_service","title": "'"$SERVICE_NAME"' Service","properties": {},"relations": {"gitlabRepository": "'"$SERVICE_NAME"'"}}'
+        -d '{"identifier": "'"$SERVICE_NAME"'_service","title": "'"$SERVICE_NAME"' Service","properties": {},"relations": {"git_lab_repositry": "'"$SERVICE_NAME"'"}}'
 
 
 # 5) Mark the run as SUCCESS and log final messages


### PR DESCRIPTION
# Description

Changed the service to gitlab relation identifier to `git_lab_repositry`

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- Scaffold new Guide (`/guides/all/scaffold-a-new-service?git-provider=gitlab`)
