### PR TITLE
Update broken section reference in azure-ad.md 

### DIFF
--- a/docs/sso-rbac/sso-providers/oidc/azure-ad.md
+++ b/docs/sso-rbac/sso-providers/oidc/azure-ad.md
@@ -129,6 +129,10 @@ To make the **Port** app connection work, users who have access need to have a l
    3.3 Search and mark the following permissions:
 
    - `email`, `openid`, `profile`, `User.read`.
+  
+   :::info  
+   If you wish to pull in AzureAD groups into Port, you will also need to add the `Directory.Read.All` permission. See [Permissions required to pull AzureAD groups to Port](#permissions-required-to-pull-azuread-groups-to-port).
+   :::
 
    ![Azure API set permissions](/img/sso/azure-ad/AzureAppAPIPermissionsSettings.png)
 
@@ -159,10 +163,6 @@ To make the **Port** app connection work, users who have access need to have a l
 4. Your optional claims will look like this:
 
    ![Azure app permissions summary](/img/sso/azure-ad/AzureAppPermissionsFinal.png)
-
-   :::info  
-   If you wish to configure the `groups claim` to pull your AzureAD groups into Port, please follow [Permissions required to pull AzureAD groups to Port](#permissions-required-to-pull-azuread-groups-to-port).
-   :::
 
 ### Step #5: Configuring application secret
 

--- a/docs/sso-rbac/sso-providers/oidc/azure-ad.md
+++ b/docs/sso-rbac/sso-providers/oidc/azure-ad.md
@@ -131,7 +131,7 @@ To make the **Port** app connection work, users who have access need to have a l
    - `email`, `openid`, `profile`, `User.read`.
 
 
-   :::info  
+   :::info AzureAD groups
    If you wish to pull in AzureAD groups into Port, you will also need to add the `Directory.Read.All` permission. See [Permissions required to pull AzureAD groups to Port](#permissions-required-to-pull-azuread-groups-to-port).
    :::
 

--- a/docs/sso-rbac/sso-providers/oidc/azure-ad.md
+++ b/docs/sso-rbac/sso-providers/oidc/azure-ad.md
@@ -161,7 +161,7 @@ To make the **Port** app connection work, users who have access need to have a l
    ![Azure app permissions summary](/img/sso/azure-ad/AzureAppPermissionsFinal.png)
 
    :::info  
-   If you wish to configure the `groups claim` to pull your AzureAD groups into Port, please follow [How to allow pulling AzureAD groups to Port](#how-to-allow-pulling-azuread-groups-to-port).
+   If you wish to configure the `groups claim` to pull your AzureAD groups into Port, please follow [Permissions required to pull AzureAD groups to Port](#permissions-required-to-pull-azuread-groups-to-port).
    :::
 
 ### Step #5: Configuring application secret

--- a/docs/sso-rbac/sso-providers/oidc/azure-ad.md
+++ b/docs/sso-rbac/sso-providers/oidc/azure-ad.md
@@ -129,7 +129,8 @@ To make the **Port** app connection work, users who have access need to have a l
    3.3 Search and mark the following permissions:
 
    - `email`, `openid`, `profile`, `User.read`.
-  
+
+
    :::info  
    If you wish to pull in AzureAD groups into Port, you will also need to add the `Directory.Read.All` permission. See [Permissions required to pull AzureAD groups to Port](#permissions-required-to-pull-azuread-groups-to-port).
    :::


### PR DESCRIPTION
# Description

The `groups claim` section does not seem to be relevant anymore, since the section it linked no longer exists on the page. The other similar section instructs the user to add additional permissions not `group claim`. Removing the info block with refers the non-existant section and updated the permission section with info about importing groups.

## Updated docs pages

- How to configure AzureAD (`sso-rbac/sso-providers/oidc/azure-ad.md`)

## Testing

We're applying this now to see whether the groups are pulled in as expected with just the `Directory.Read.All` permission or whether there is an actual section on `groups claim` missing in the docs.
