### PR TITLE
Added tip to GCP guide about enabling cloud quotas api on projects while creating service accounts

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/_create-service-account-and-key.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/_create-service-account-and-key.mdx
@@ -1,5 +1,10 @@
 <h2> Creating a service account </h2>
 
+:::tip Enable Cloud Quotas API
+To avoid permission issues while running the GCP integration, make sure the Cloud Quotas API is enabled in your project.
+You can enable it by following the instructions in [this guide](https://cloud.google.com/docs/quotas/development-environment).
+:::
+
 1. Make sure you have your selected project in the top left toggle.
 
    <img src='/img/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/select_project.png' width='50%' border='1px' /> <br/><br/>


### PR DESCRIPTION
# Description

Added a note in the installation guide of GCP integration (within the "Creating a service account" section) to instruct users to enable the Cloud Quotas API for the project while setting up the integration

## Updated docs pages

Please also include the path for the updated docs

- GCP Installation (`/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/installation`)
