### PR TITLE
Fix port-sender version in slack-reminder self service action doc (bug fix)

### DIFF
--- a/docs/guides/all/setup-slack-reminders.md
+++ b/docs/guides/all/setup-slack-reminders.md
@@ -169,7 +169,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Generate Scorecards Reminders
-              uses: port-labs/port-sender@v0.2.3
+              uses: port-labs/port-sender@v0.2.14
               with:
                 operation_kind: scorecard_reminder
                 port_client_id: ${{ secrets.PORT_CLIENT_ID }}


### PR DESCRIPTION
# Description

the current guide resulting an error, upgrading the port-sender version from 0.2.3 to 0.2.14 resolves it.


## Updated docs pages
https://docs.port.io/guides/all/setup-slack-reminders