### PR TITLE
feat: replace cloud control api links with the API docs

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources.md
@@ -70,7 +70,7 @@ The mapping makes use of the [JQ JSON processor](https://stedolan.github.io/jq/m
 
 ### `useGetResourceAPI` property support
 
-- By default the integration uses the [`CloudControl:ListResources`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/list-resources.html) API to get the resources. The integration can also enrich each resource by running [`CloudControl:GetResource`](https://docs.aws.amazon.com/cli/latest/reference/cloudcontrol/get-resource.html) on each resource, you can use this by enabling `useGetResourceAPI` option.
+- By default the integration uses the [`CloudControl:ListResources`](https://docs.aws.amazon.com/cloudcontrolapi/latest/APIReference/API_ListResources.html) API to get the resources. The integration can also enrich each resource by running [`CloudControl:GetResource`](https://docs.aws.amazon.com/cloudcontrolapi/latest/APIReference/API_GetResource.html) on each resource, you can use this by enabling `useGetResourceAPI` option.
 
   The `useGetResourceAPI` option is only available for resources that support the `CloudControl:GetResource` API.
 


### PR DESCRIPTION
# Description

Replaced AWS CLI documentation with Cloud Control API documentation

## Updated docs pages

Please also include the path for the updated docs

- Mapping Extra Resources
 (`/build-your-software-catalog/sync-data-to-catalog/cloud-providers/aws/examples/mapping_extra_resources/#usegetresourceapi-property-support `)
- ...
