### PR TITLE
PORT-13567 Add-callout-for-existing-integration-secrets-in-add-port-secrets-guide

### DIFF
--- a/docs/guides/all/acknowledge-incident.md
+++ b/docs/guides/all/acknowledge-incident.md
@@ -47,9 +47,17 @@ However, we highly recommend you install the PagerDuty integration to have these
 
     <h3> Add Port secrets </h3>
 
-    Add the following secrets to your Port account:
+    :::tip Existing secrets
+    If you have already installed Port's PagerDuty integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add this secret to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/add-tags-to-sonarqube-project.md
+++ b/docs/guides/all/add-tags-to-sonarqube-project.md
@@ -122,9 +122,17 @@ However, we highly recommend you install the SonarQube integration to have these
 
     <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's SonarQube integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/change-status-and-assignee-of-jira-ticket.md
+++ b/docs/guides/all/change-status-and-assignee-of-jira-ticket.md
@@ -186,9 +186,17 @@ However we highly recommend you install the Jira integration to have these autom
 
     <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's Jira integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/create-jira-issue-from-dependabot.md
+++ b/docs/guides/all/create-jira-issue-from-dependabot.md
@@ -258,9 +258,17 @@ Follow this [resource mapping guide](https://docs.port.io/build-your-software-ca
 
     <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's Jira integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/create-pagerduty-incident.md
+++ b/docs/guides/all/create-pagerduty-incident.md
@@ -173,11 +173,19 @@ However, we highly recommend you install the PagerDuty integration to have these
 
     You can create PagerDuty incidents by leveraging Port's **synced webhooks** and **secrets** to directly interact with the PagerDuty's API. This method simplifies the setup by handling everything within Port.
 
-    <h3> Add Port secrets </h3>
+    <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's PagerDuty integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/create-pagerduty-service.md
+++ b/docs/guides/all/create-pagerduty-service.md
@@ -95,11 +95,19 @@ However, we highly recommend you install the PagerDuty integration to have these
 
     You can create PagerDuty services by leveraging Port's **synced webhooks** and **secrets** to directly interact with the PagerDuty's API. This method simplifies the setup by handling everything within Port.
 
-    <h3> Add Port secrets </h3>
+    <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's PagerDuty integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/escalate-an-incident.md
+++ b/docs/guides/all/escalate-an-incident.md
@@ -45,9 +45,19 @@ However, we highly recommend you install the PagerDuty integration to have these
    
     You can escalate PagerDuty incidents by leveraging Port's **synced webhooks** and **secrets** to directly interact with the PagerDuty's API. This method simplifies the setup by handling everything within Port.
 
-    <h3> Add Port secrets </h3>
+    <h3>Add Port secrets</h3>
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    :::info Existing secrets
+    If you have already installed Port's PagerDuty integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
+
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/open-jira-issue-with-automatic-label.md
+++ b/docs/guides/all/open-jira-issue-with-automatic-label.md
@@ -215,9 +215,17 @@ You should have installed the [Port's GitHub app](https://github.com/apps/getpor
 
     <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's Jira integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/report-a-bug.md
+++ b/docs/guides/all/report-a-bug.md
@@ -116,9 +116,17 @@ However we highly recommend you install the Jira integration to have these autom
 
     <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's Jira integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/resolve-incident.md
+++ b/docs/guides/all/resolve-incident.md
@@ -47,9 +47,17 @@ However, we highly recommend you install the PagerDuty integration to have these
 
     <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's PagerDuty integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/toggle-launchdarkly-feature-flag.md
+++ b/docs/guides/all/toggle-launchdarkly-feature-flag.md
@@ -137,9 +137,17 @@ However, we highly recommend you install the LaunchDarkly integration to have th
 
     <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's LaunchDarkly integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/trigger-datadog-incident.md
+++ b/docs/guides/all/trigger-datadog-incident.md
@@ -132,9 +132,17 @@ However we highly recommend you install the Datadog integration to have this aut
 
     <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's Datadog integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/trigger-pagerduty-incident.md
+++ b/docs/guides/all/trigger-pagerduty-incident.md
@@ -60,7 +60,17 @@ However, we highly recommend you install the PagerDuty integration to have these
 
     <h3>Add Port secrets</h3>
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    :::info Existing secrets
+    If you have already installed Port's PagerDuty integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
+
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 

--- a/docs/guides/all/trigger-servicenow-incident.md
+++ b/docs/guides/all/trigger-servicenow-incident.md
@@ -108,9 +108,17 @@ However, we highly recommend you install the ServiceNow integration to have thes
 
     <h3>Add Port secrets</h3>
 
-    Add the following secrets to your Port account:
+    :::info Existing secrets
+    If you have already installed Port's ServiceNow integration, these secrets should already exist in your portal.  
+    To view your existing secrets:
+    1. Click on the `...` button next to the profile icon in the top right corner
+    2. Click on **Credentials**
+    3. Click on the `Secrets` tab
+    :::
 
-    1. In your portal, click on the `...` button next to the profile icon in the top right corner.
+    To add these secrets to your portal:
+
+    1. Click on the `...` button next to the profile icon in the top right corner.
 
     2. Click on **Credentials**.
 


### PR DESCRIPTION
# Description

Update documentation to clarify existing secrets for integrations


## Updated docs pages

Please also include the path for the updated docs

- Acknowledge Incident (`/guides/all/acknowledge-incident`)
- Escalate Incident (`/guides/all/escalate-an-incident)`)
- Create PagerDuty Incident (`/guides/all/create-pagerduty-incident`)
- Create PagerDuty Service (`guides/all/create-pagerduty-service`)
- Resolve PagerDuty Incident (`/guides/all/resolve-incident`)
- Trigger PagerDuty Incident (`/guides/all/trigger-pagerduty-incident`)
- Add Tags to SonarQube Project (`/guides/all/add-tags-to-sonarqube-project`)
- Toggle LaunchDarkly Feature Flag (`/guides/all/toggle-launchdarkly-feature-flag`)
- Trigger Datadog Incident (`/guides/all/trigger-datadog-incident`)
- Trigger ServiceNow Incident (`/guides/all/trigger-servicenow-incident`)
- Change status and assignee of Jira ticket (`/guides/all/change-status-and-assignee-of-jira-ticket`)
- Create Jira Issue from Dependabot Alert (`/guides/all/create-jira-issue-from-dependabot`)
- Open Jira issue with automatic label (`/guides/all/open-jira-issue-with-automatic-label`)
- Report a bug (`/guides/all/report-a-bug`)
