### PR TITLE
Update our Terraform provider version to latest minor

### DIFF
--- a/docs/build-your-software-catalog/custom-integration/iac/terraform/_terraform_provider_base.mdx
+++ b/docs/build-your-software-catalog/custom-integration/iac/terraform/_terraform_provider_base.mdx
@@ -11,7 +11,7 @@ terraform {
   required_providers {
     port = {
       source  = "port-labs/port-labs"
-      version = "~> 2.0.3"
+      version = "~> 2.4.0"
     }
   }
 }


### PR DESCRIPTION
# Description

The version mentioned in the docs is more than 3 months old with many new feature missing (2.0.X vs 2.4.Y)

![Screenshot 2025-03-16 at 11 41 12](https://github.com/user-attachments/assets/8935e341-a8fc-49d1-8971-c2beddcd0fca)

![Screenshot 2025-03-16 at 11 48 59](https://github.com/user-attachments/assets/2a993d43-f11e-404e-b4db-a30e87cd3763)


## Added docs pages

N/A

## Updated docs pages

Please also include the path for the updated docs

- [Terraform - Installation](https://docs.port.io/build-your-software-catalog/custom-integration/iac/terraform/#installation)
