### PR TITLE
PORT-13370-bug-the-example-should-be-updated-to-the-new-users-and-teams-version

### DIFF
--- a/docs/sso-rbac/rbac/as-blueprints.md
+++ b/docs/sso-rbac/rbac/as-blueprints.md
@@ -256,7 +256,7 @@ You can also change the `title` of the ownership property. The default value is 
                "property": "$team",
                "operator": "containsAny",
                "value": {
-                 "jqQuery": ".user.teamsIdentifiers"
+                 "jqQuery": ".user.team" 
                }
              }
            ]

--- a/docs/sso-rbac/rbac/as-blueprints.md
+++ b/docs/sso-rbac/rbac/as-blueprints.md
@@ -256,7 +256,7 @@ You can also change the `title` of the ownership property. The default value is 
                "property": "$team",
                "operator": "containsAny",
                "value": {
-                 "jqQuery": "[.user.team]"
+                 "jqQuery": ".user.teamsIdentifiers"
                }
              }
            ]


### PR DESCRIPTION

# Description

Update jqQuery in RBAC documentation to use teamsIdentifiers

Non-working: [.user.team] (doesn't work because it doesn't properly access the team data) Working but not optimal: 

[.user.team[]] (works but doesn't take full advantage of the new structure) 

Optimal  approach:".user.team"It's simpler and more readable
It does exactly what we need without any extra complexity


## Updated docs pages

Please also include the path for the updated docs

- As blueprint (New)(`/sso-rbac/rbac/as-blueprints/#self-service-actions`)
