### PR TITLE
PORT-13415-bug-to-mention-that-user-deprovisioning-in-okta-saml-scim-is-not-visually-displayed-on-ports-ui

### DIFF
--- a/docs/sso-rbac/sso-providers/saml/okta.md
+++ b/docs/sso-rbac/sso-providers/saml/okta.md
@@ -88,7 +88,7 @@ Okta supports [SCIM](https://auth0.com/docs/authenticate/protocols/scim) for SAM
 <ScimFunctionality/>
 
 :::info User deprovisioning
-When using SCIM with Okta SAML, if a user is unassigned from the SSO application in Okta, they will automatically lose access to Port. This deprovisioning works at the Auth0 level - meaning the user's ability to access the system is restricted at our login provider. 
+When using SCIM with Okta SAML, if a user is unassigned from the SSO application in Okta, they will automatically lose access to Port. Deprovisioning works at the Auth0 level - meaning the user's account will be blocked by the login provider.  
 However, this change will not be reflected in the portal's "Users and teams" page.
 :::
 

--- a/docs/sso-rbac/sso-providers/saml/okta.md
+++ b/docs/sso-rbac/sso-providers/saml/okta.md
@@ -88,9 +88,8 @@ Okta supports [SCIM](https://auth0.com/docs/authenticate/protocols/scim) for SAM
 <ScimFunctionality/>
 
 :::info User deprovisioning
-When using SCIM with Okta SAML, user deprovisioning works at the Auth0 level , the user will automatically lose access to Port. 
-However, this change is not visually reflected in Port's users and teams page.   
-The user's ability to access the system is restricted at the Auth0 level, our login provider.
+When using SCIM with Okta SAML, if a user is unassigned from the SSO application in Okta, they will automatically lose access to Port. This deprovisioning works at the Auth0 level - meaning the user's ability to access the system is restricted at our login provider. 
+However, this change will not be reflected in the portal's "Users and teams" page.
 :::
 
 ### Setup SCIM

--- a/docs/sso-rbac/sso-providers/saml/okta.md
+++ b/docs/sso-rbac/sso-providers/saml/okta.md
@@ -11,7 +11,7 @@ import DirectUrl from "/docs/generalTemplates/_sso_direct_url.md"
 
 Follow this step-by-step guide to configure the integration between Port and Okta using a SAML application.
 
-:::info
+:::info Port support
 To complete the process, you will need to contact us to receive the necessary information and provide the details Port requires from you.
 
 The Port team will provide you with your `CONNECTION_NAME`, which will be used in the SSO application's configuration.
@@ -26,17 +26,24 @@ The Port team will provide you with your `CONNECTION_NAME`, which will be used i
 ## Register a new application and generate the required credentials
 
 1. Sign in to your Okta Admin Console.
+
 2. Navigate to `Applications` and click on `Applications` again.
+
 3. Click on the `Create App Integration` button.
+
 4. In the pop-up, select `SAML 2.0` and click on `Next`.
+
 5. In the `General Settings`, enter a name for the application and click on `Next`.
-6. On the `Configure SAML` page, under `SAML Settings`, you’ll need to fill in some details:
+
+6. On the `Configure SAML` page, under `SAML Settings`, you will need to fill in some details:
     - **Single sign on URL**: `https://auth.getport.io/login/callback?connection={CONNECTION_NAME}`
     - **Audience URI (SP Entity ID)**: `urn:auth0:port-prod:{CONNECTION_NAME}`
+
 7. Scroll down to the `Attribute Statements (Optional)` section and add the following:
     - `email`, with the `Value` set to `user.email`
     - `given_name`, with the `Value` set to `user.firstName`
     - `family_name`, with the `Value` set to `user.lastName`
+
 8. Click `Next` and then `Finish` to create the application.
 
 ## Generate a Certificate and Send to Port
@@ -44,10 +51,15 @@ The Port team will provide you with your `CONNECTION_NAME`, which will be used i
 To secure the SAML integration, you need to generate a certificate and send it to Port:
 
 1. In the Okta Admin Console, navigate to `Applications`, and select the newly created SAML application.
+
 2. Go to the `Sign On` tab and scroll down to the `SAML Signing Certificates` section.
+
 3. Click on `Generate new certificate`.
+
 4. In the dialog, specify the certificate details such as the name and duration, then click `Generate`.
+
 5. After generating the certificate, download it by clicking on the `Actions` button next to the new certificate and selecting `Download certificate`. Choose the `PEM` format.
+
 6. Send the **PEM certificate file** along with the **Identity Provider metadata URL** (available in the `Sign On` tab) to Port.
 
 <DirectUrl/>
@@ -57,11 +69,14 @@ To secure the SAML integration, you need to generate a certificate and send it t
 To expose your Okta groups to Port via the application, follow these steps:
 
 1. In the `Sign On` tab of your Okta application, click `Edit`.
+
 2. Scroll down to the `Group Attribute Statements` section.
+
 3. Add a group attribute using the following settings:
     - **Name**: `groups`
     - **Filter**: `Regex`
     - **Value**: Use a regular expression that matches the groups you wish to send to Port (e.g., `.*` for all groups or a specific pattern).
+
 4. Save your changes.
 
 These groups will be ingested into Port as teams, enabling you to manage user permissions and RBAC in your Port account.
@@ -71,6 +86,12 @@ These groups will be ingested into Port as teams, enabling you to manage user pe
 Okta supports [SCIM](https://auth0.com/docs/authenticate/protocols/scim) for SAML applications.
 
 <ScimFunctionality/>
+
+:::info User deprovisioning
+When using SCIM with Okta SAML, user deprovisioning works at the Auth0 level , the user will automatically lose access to Port. 
+However, this change is not visually reflected in Port's users and teams page.   
+The user's ability to access the system is restricted at the Auth0 level, our login provider.
+:::
 
 ### Setup SCIM
 
@@ -84,7 +105,7 @@ You will be provided with:
 
 Once you have received the SCIM `endpoint` and `token`, follow Okta’s documentation on [Setting Up SCIM in Okta](https://help.okta.com/en-us/content/topics/apps/apps_app_integration_wizard_scim.htm) to enable SCIM.
 
-:::note
+:::tip Configuring SCIM
 When configuring SCIM:
 
 - Set the `Unique identifier field` to `userName`.


### PR DESCRIPTION

# Description

Update Okta SAML documentation for clarity and add user deprovisioning info

## Updated docs pages

Please also include the path for the updated docs

- How to configure Okta (`/sso-rbac/sso-providers/saml/okta#scim-configuration-beta`)
