### PR TITLE
Added permissions tip in gitlab

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
@@ -80,9 +80,10 @@ The following steps will guide you how to create a GitLab group access token.
 
    <img src='/img/integrations/gitlab/GitLabGroupAccessTokens.png' width='85%' border='1px' />
 
-  :::tip
-  While `Owner` permissions are recommended, you can use the `filterOwnedProjects: false` flag in the mapping to set lower permission levels (for more information, [refer to the Advanced configurations tab](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/advanced/?parameter=filterOwnedProjects#using-advanced-configurations)). *Please note that using lower permissions may lead to unexpected behavior.*
-  :::
+    :::tip
+    While `Owner` permissions are recommended, you can use the `filterOwnedProjects: false` flag in the mapping to set lower permission levels (for more information, [refer to the Advanced configurations tab](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/advanced/?parameter=filterOwnedProjects#using-advanced-configurations)).  
+    *Please note that using lower permissions may lead to unexpected behavior.*
+    :::
 
 3. Click "Create group access token".
 4. Copy the generated token and use it when deploying the integration in the following steps.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
@@ -80,9 +80,9 @@ The following steps will guide you how to create a GitLab group access token.
 
    <img src='/img/integrations/gitlab/GitLabGroupAccessTokens.png' width='85%' border='1px' />
 
-:::tip
-While Owner permissions are recommended, you can use the `filterOwnedProjects: false` flag in the mapping to set lower permission levels (for more information, [refer to the Advanced configuraitons tab](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/advanced/?parameter=filterOwnedProjects#using-advanced-configurations)). *Please note that using lower permissions may lead to unexpected behavior.*
-:::
+  :::tip
+  While `Owner` permissions are recommended, you can use the `filterOwnedProjects: false` flag in the mapping to set lower permission levels (for more information, [refer to the Advanced configurations tab](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/advanced/?parameter=filterOwnedProjects#using-advanced-configurations)). *Please note that using lower permissions may lead to unexpected behavior.*
+  :::
 
 3. Click "Create group access token".
 4. Copy the generated token and use it when deploying the integration in the following steps.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
@@ -80,6 +80,10 @@ The following steps will guide you how to create a GitLab group access token.
 
    <img src='/img/integrations/gitlab/GitLabGroupAccessTokens.png' width='85%' border='1px' />
 
+:::tip
+While Owner permissions are recommended, you can use the `filterOwnedProjects` flag in the mapping to set lower permission levels (for more information, [refer to the Advanced configuraitons tab](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/advanced/?parameter=filterOwnedProjects#using-advanced-configurations)). *Please note that using lower permissions may lead to unexpected behavior.*
+:::
+
 3. Click "Create group access token".
 4. Copy the generated token and use it when deploying the integration in the following steps.
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation.md
@@ -81,7 +81,7 @@ The following steps will guide you how to create a GitLab group access token.
    <img src='/img/integrations/gitlab/GitLabGroupAccessTokens.png' width='85%' border='1px' />
 
 :::tip
-While Owner permissions are recommended, you can use the `filterOwnedProjects` flag in the mapping to set lower permission levels (for more information, [refer to the Advanced configuraitons tab](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/advanced/?parameter=filterOwnedProjects#using-advanced-configurations)). *Please note that using lower permissions may lead to unexpected behavior.*
+While Owner permissions are recommended, you can use the `filterOwnedProjects: false` flag in the mapping to set lower permission levels (for more information, [refer to the Advanced configuraitons tab](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/advanced/?parameter=filterOwnedProjects#using-advanced-configurations)). *Please note that using lower permissions may lead to unexpected behavior.*
 :::
 
 3. Click "Create group access token".


### PR DESCRIPTION
# Description

Added a tooltip indicating that you can use alternative permissions model for gitlab at your own risk.

## Updated docs pages

- gitlab installation (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab/installation`)