### PR TITLE
docs: clarify the maximum number of entities for aggregation property

### DIFF
--- a/docs/build-your-software-catalog/customize-integrations/configure-data-model/setup-blueprint/properties/aggregation-property.md
+++ b/docs/build-your-software-catalog/customize-integrations/configure-data-model/setup-blueprint/properties/aggregation-property.md
@@ -907,4 +907,5 @@ Coming soon...
 
 - The aggregation property value for all entities of a blueprint will be recalculated **every 15 minutes**.
 
-- The maximum number of entities that can be aggregated is **20,000**.
+- The maximum number of entities in the blueprint where the aggregation property is defined is **20,000**.
+


### PR DESCRIPTION
PORT-13811

# Description

The documentation now specifies that the maximum number of entities in the blueprint where the aggregation property is defined is 20,000.

## Added docs pages

N/A

## Updated docs pages

docs/build-your-software-catalog/customize-integrations/configure-data-model/setup-blueprint/properties/aggregation-property.md