### PR TITLE
Remove webhook secret hint from warning

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
@@ -29,7 +29,7 @@ This integration allows you to:
 ## BaseUrl & Webhook Configuration
 
 :::warning AppHost deprecation
-- **`integration.config.appHost` is deprecated**: Please use `baseUrl` for webhook URL settings instead.
+**`integration.config.appHost` is deprecated**: Please use `baseUrl` for webhook URL settings instead.
 :::
 
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
@@ -29,16 +29,17 @@ This integration allows you to:
 ## BaseUrl & Webhook Configuration
 
 :::warning Deprecated
-### Important Update
 - **`integration.config.appHost` is deprecated**: Please use `baseUrl` for webhook URL settings instead.
 :::
-- **Webhook secret support (Optional)**: Secure your webhooks using [`webhookSecret`](https://docs.sonarsource.com/sonarqube-server/latest/project-administration/webhooks/).
 
 
 The `baseUrl` parameter enables real-time updates from Datadog to Port. If not provided:
 - The integration will still function normally
 - You'll need to use [`scheduledResyncInterval`](https://ocean.getport.io/develop-an-integration/integration-configuration/#scheduledresyncinterval---run-scheduled-resync) for updates
 - Manual resyncs can be triggered via Port's UI
+
+The `integration.secrets.webhookSecret` parameter secures your webhooks. If not provided:
+  - The integration will process webhooks without validating the source of the events
 
 ### Supported Resources
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
@@ -28,7 +28,7 @@ This integration allows you to:
 
 ## BaseUrl & Webhook Configuration
 
-:::warning Deprecated
+:::warning AppHost deprecation
 - **`integration.config.appHost` is deprecated**: Please use `baseUrl` for webhook URL settings instead.
 :::
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
@@ -28,18 +28,17 @@ This integration allows you to:
 
 ## BaseUrl & Webhook Configuration
 
-:::warning
+:::warning Deprecated
 ### Important Update
 - **`integration.config.appHost` is deprecated**: Please use `baseUrl` for webhook URL settings instead.
-- **Webhook secret support**: Secure your webhooks using `webhookSecret`.
 :::
+- **Webhook secret support (Optional)**: Secure your webhooks using [`webhookSecret`](https://docs.sonarsource.com/sonarqube-server/latest/project-administration/webhooks/).
 
-:::tip
+
 The `baseUrl` parameter enables real-time updates from Datadog to Port. If not provided:
 - The integration will still function normally
 - You'll need to use [`scheduledResyncInterval`](https://ocean.getport.io/develop-an-integration/integration-configuration/#scheduledresyncinterval---run-scheduled-resync) for updates
 - Manual resyncs can be triggered via Port's UI
-:::
 
 ### Supported Resources
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/sonarqube.md
@@ -38,8 +38,7 @@ The `baseUrl` parameter enables real-time updates from Datadog to Port. If not p
 - You'll need to use [`scheduledResyncInterval`](https://ocean.getport.io/develop-an-integration/integration-configuration/#scheduledresyncinterval---run-scheduled-resync) for updates
 - Manual resyncs can be triggered via Port's UI
 
-The `integration.secrets.webhookSecret` parameter secures your webhooks. If not provided:
-  - The integration will process webhooks without validating the source of the events
+The `integration.secrets.webhookSecret` parameter secures your webhooks. If not provided, the integration will process webhooks without validating the source of the events
 
 ### Supported Resources
 


### PR DESCRIPTION
# Description

Added Optional for webhook secret

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
