### PR TITLE
Removed ttl limitation from Ocean SaaS

### DIFF
--- a/src/components/ocean-saas-specifics/limitations.jsx
+++ b/src/components/ocean-saas-specifics/limitations.jsx
@@ -1,14 +1,22 @@
 import Markdown from "@theme/Markdown";
 
+const defaultLimitations = {
+  ttl:
+    '- The maximum time for a full sync to run is based on the Resync interval. For very large amounts of data where a resync operation is expected to take longer, please use a longer Resync interval.',
+};
+
 const limitations = {
   Snyk:
+    defaultLimitations.ttl + '\n' +
     '- Due to Snyk\'s v1 + REST API [limitations](https://docs.snyk.io/snyk-api/api-endpoints-index-and-tips/issue-ids-in-snyk-apis), only project and target related events are supported.' + '\n' +
     '- No deletion events are supported in Snyk.',
   Jira:
+    defaultLimitations.ttl + '\n' +
     '- For OAuth based installations:'+ '\n' +
     '    - Due to restrictions on the [Jira OAuth Dynamic Webhooks API](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-webhooks/#api-group-webhooks), Only issue related live events are supported.' + '\n' +
-    '    - Due to restrictions on the [Jira OAuth2 App](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-webhooks/#api-rest-api-2-webhook-post), Only a single OAuth Jira installation will recieve live events.',
+    '    - Due to restrictions on the [Jira OAuth2 App](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-webhooks/#api-rest-api-2-webhook-post), Only a single OAuth Jira installation will recieve live events.' + '\n',
   Gitlab:
+    defaultLimitations.ttl + '\n' +
     '- For OAuth based installations:' + '\n' +
     '    - Resync times are limited to 1 hour.' + '\n'
 }
@@ -17,7 +25,7 @@ const OceanSaasLimitations = ({ id }) => {
 
   return (
     <Markdown>
-      {limitations[id]}
+      {limitations[id] || defaultLimitations["ttl"]}
     </Markdown>
   );
 };

--- a/src/components/ocean-saas-specifics/limitations.jsx
+++ b/src/components/ocean-saas-specifics/limitations.jsx
@@ -1,27 +1,23 @@
 import Markdown from "@theme/Markdown";
 
-const defaultLimitations = {
-  ttl:
-    '- Resync jobs have a TTL of 1 hour.  \nFor very large amounts of data where a resync operation is expected to take longer, please use a different installation method or contact support.',
-};
-
 const limitations = {
   Snyk:
-    defaultLimitations.ttl + '\n' +
     '- Due to Snyk\'s v1 + REST API [limitations](https://docs.snyk.io/snyk-api/api-endpoints-index-and-tips/issue-ids-in-snyk-apis), only project and target related events are supported.' + '\n' +
     '- No deletion events are supported in Snyk.',
   Jira:
-    defaultLimitations.ttl + '\n' +
     '- For OAuth based installations:'+ '\n' +
     '    - Due to restrictions on the [Jira OAuth Dynamic Webhooks API](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-webhooks/#api-group-webhooks), Only issue related live events are supported.' + '\n' +
-    '    - Due to restrictions on the [Jira OAuth2 App](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-webhooks/#api-rest-api-2-webhook-post), Only a single OAuth Jira installation will recieve live events.'
+    '    - Due to restrictions on the [Jira OAuth2 App](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-webhooks/#api-rest-api-2-webhook-post), Only a single OAuth Jira installation will recieve live events.',
+  Gitlab:
+    '- For OAuth based installations:' + '\n' +
+    '    - Resync times are limited to 1 hour.' + '\n'
 }
 
 const OceanSaasLimitations = ({ id }) => {
 
   return (
     <Markdown>
-      {limitations[id] || defaultLimitations["ttl"]}
+      {limitations[id]}
     </Markdown>
   );
 };

--- a/src/components/ocean-saas-specifics/limitations.jsx
+++ b/src/components/ocean-saas-specifics/limitations.jsx
@@ -2,7 +2,7 @@ import Markdown from "@theme/Markdown";
 
 const defaultLimitations = {
   ttl:
-    '- The maximum time for a full sync to run is based on the Resync interval. For very large amounts of data where a resync operation is expected to take longer, please use a longer Resync interval.',
+    '- The maximum time for a full sync to run is based on the configured resync interval. For very large amounts of data where a resync operation is expected to take longer, please use a longer interval.',
 };
 
 const limitations = {

--- a/src/components/ocean-saas-specifics/live-events.jsx
+++ b/src/components/ocean-saas-specifics/live-events.jsx
@@ -1,6 +1,4 @@
 import Markdown from "@theme/Markdown";
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 
 const defaultLiveEvents = {
   unsupported:


### PR DESCRIPTION
# Description

Removed the default limitation for SaaS Ocean integration about resync times

## Updated docs pages

Please also include the path for the updated docs

- Ocean SaaS integrations
