### PR TITLE
Update GitLab and Gitlab-v2 integration slugs

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
@@ -5,7 +5,7 @@ import GitLabResources from './_gitlab_integration_supported_resources.mdx'
 
 # GitLab
 
-:::info
+:::info GitLab v2 documentation
 This page documents the latest GitLab integration, released in April 2025.  
 For documentation of the previous integration, check out the [GitLab (deprecated)](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/) page.  
 :::

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
@@ -5,6 +5,10 @@ import GitLabResources from './_gitlab_integration_supported_resources.mdx'
 
 # GitLab
 
+:::info
+You’re viewing the latest GitLab integration, released in April 2025. For details on the previous version, check out the [GitLab (deprecated)](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/) documentation.  
+:::
+
 Port's GitLab-v2 integration allows you to model GitLab resources in your software catalog and ingest data into them.
 
 ## Overview

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
@@ -6,7 +6,8 @@ import GitLabResources from './_gitlab_integration_supported_resources.mdx'
 # GitLab
 
 :::info
-You’re viewing the latest GitLab integration, released in April 2025. For details on the previous version, check out the [GitLab (deprecated)](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/) documentation.  
+This page documents the latest GitLab integration, released in April 2025.  
+For documentation of the previous integration, check out the [GitLab (deprecated)](/build-your-software-catalog/sync-data-to-catalog/git/gitlab/) page.  
 :::
 
 Port's GitLab-v2 integration allows you to model GitLab resources in your software catalog and ingest data into them.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/_category_.json
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/_category_.json
@@ -1,4 +1,4 @@
 {
-    "label": "GitLab v2 (beta)",
+    "label": "GitLab",
     "position": 3
 }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_category_.json
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "GitLab",
+  "label": "GitLab (deprecated)",
   "position": 3
 }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/gitlab.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/gitlab.md
@@ -5,6 +5,12 @@ import TabItem from "@theme/TabItem"
 
 Port's GitLab integration allows you to model GitLab resources in your software catalog and ingest data into them.
 
+:::warning Deprecation Notice
+This app will be deprecated in the future and support for the app will be discontinued soon.
+
+To integrate Port with GitLab, we recommend using the [GitLab V2 integration](/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/).
+:::
+
 ## Overview
 
 This integration allows you to:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/gitlab.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab/gitlab.md
@@ -6,7 +6,7 @@ import TabItem from "@theme/TabItem"
 Port's GitLab integration allows you to model GitLab resources in your software catalog and ingest data into them.
 
 :::warning Deprecation Notice
-This app will be deprecated in the future and support for the app will be discontinued soon.
+This integration will be deprecated in the future and support for it will be discontinued soon.
 
 To integrate Port with GitLab, we recommend using the [GitLab V2 integration](/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/).
 :::


### PR DESCRIPTION
# Update GitLab integration documentation: mark v2 as latest and deprecate v1

## Description

This update marks GitLab v2 as the latest version, released in April 2025, and deprecates the previous version (v1). The change includes updates to documentation paths, labels, and deprecation notices. This update ensures users are directed to the new version while still providing information on the deprecated version for reference.

## Added docs pages
- None

## Updated docs pages
- - GitLab v2 Integration (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md`)
- GitLab Integration Overview (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab/gitlab.md`): Updated to include a deprecation notice for GitLab v1 and direct users to the GitLab v2 integration.
- GitLab v2 Category (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/_category_.json`): Updated label to "GitLab" and adjusted the position.
- GitLab (deprecated) Category (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab/_category_.json`): Updated label to "GitLab (deprecated)" for clarity.
