### PR TITLE
Update create-azure-resource.md - use RG from secret

### DIFF
--- a/docs/guides/all/create-azure-resource.md
+++ b/docs/guides/all/create-azure-resource.md
@@ -408,7 +408,7 @@ jobs:
             TF_VAR_port_client_id: ${{ secrets.PORT_CLIENT_ID }}
             TF_VAR_port_client_secret: ${{ secrets.PORT_CLIENT_SECRET }}
             TF_VAR_port_run_id: ${{fromJson(inputs.port_context).runId}}
-            TF_VAR_resource_group_name: arete-resources
+            TF_VAR_resource_group_name: ${{ secrets.AZURE_RESOURCE_GROUP }}
         run: |
           terraform plan \
             -input=false \


### PR DESCRIPTION
The step of Run TF Plan/Apply (Port) was not using the RG Name from the secret and had a hardcoded name.

# Description

Change to remove the hardcoded RG name and use the RG Name from the secret.

## Added docs pages

Please also include the path for the added docs

No necessary changes on other documentation, it was a error on the example.

## Updated docs pages

No necessary changes on other documentation, it was a error on the example.
