### PR TITLE
Update GitLab v2 , Bump to GA

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
@@ -3,7 +3,7 @@ import TabItem from "@theme/TabItem"
 
 import GitLabResources from './_gitlab_integration_supported_resources.mdx'
 
-# GitLab v2 (beta)
+# GitLab v2
 
 :::info GitLab v2 documentation
 This page documents the latest GitLab integration, released in April 2025.  

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/_category_.json
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "GitLab v2 (beta)",
+  "label": "GitLab v2",
   "position": 3
 }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/example-groups/_gitlab_integration_example_group_members_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/example-groups/_gitlab_integration_example_group_members_config.mdx
@@ -8,7 +8,7 @@ resources:
         mappings:
           identifier: .full_path
           title: .name
-          blueprint: '"gitlabGroupWithMember"'
+          blueprint: '"gitlabGroup"'
           properties:
             url: .web_url
             visibility: .visibility

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/installation.md
@@ -80,16 +80,16 @@ Choose one of the following installation methods:
 
 <Tabs groupId="installation-methods" queryString="installation-methods">
 
+<TabItem value="hosted-by-port" label="Hosted by Port" default>
+
+<OceanSaasInstallation integration="GitLab_v2" />
+
+</TabItem>
+
 <TabItem value="real-time-self-hosted" label="Real-time (self-hosted)">
 
+Using this installation option means that the integration will be able to update Port in real time using webhooks.
 
-<OceanSaasLiveEventsDescription id="GitLab_v2"/>
-<div>
-<details>
-<summary><b>Supported live event triggers</b></summary>
-<OceanSaasLiveEventsTriggersManual id="GitLab_v2" isOAuth={false} />
-</details>
-</div>
 <h2>Prerequisites</h2>
 
 <Prerequisites />


### PR DESCRIPTION
# Description

Updated GitLab v2 integration docs:
- Changed blueprint from `gitlabGroupWithMember` to `gitlabGroup` in group members config.
- Added "Hosted by Port" the default tab in installation guide and replaced live events section with a webhook update note.

## Added docs pages

- None

## Updated docs pages

- Group Members Config (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/example-groups/_gitlab_integration_example_group_members_config.mdx`)
- Installation Guide (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/installation.md`)