### PR TITLE
Fix cloud resource workflow

### DIFF
--- a/docs/guides/all/create-cloud-resource-using-iac.md
+++ b/docs/guides/all/create-cloud-resource-using-iac.md
@@ -288,7 +288,7 @@ Now we want to write the logic that our action will trigger.
           # Checkout the service's repository
           - uses: actions/checkout@v4
             with:
-              repository: "${{ github.repository_owner }}/${{ fromJson(inputs.port_context).entity }}"
+              repository: "${{ fromJson(inputs.port_context).entity }}"
               path: ./targetRepo
               token: ${{ secrets.ORG_ADMIN_TOKEN }}
           - name: Copy template file
@@ -325,7 +325,7 @@ Now we want to write the logic that our action will trigger.
               blueprint: githubRepository
               properties: |-
                 {
-                  "resource_definitions": "${{ github.server_url }}/${{ github.repository_owner }}/${{ fromJson(inputs.port_context).entity }}/blob/main/resources/"
+                  "resource_definitions": "${{ github.server_url }}/${{ fromJson(inputs.port_context).entity }}/blob/main/resources/"
                 }
               clientId: ${{ secrets.PORT_CLIENT_ID }}
               clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}


### PR DESCRIPTION
# Description

Changed the workflow in the guide.
Since the repository mapping is .full_name, the repo identifier shouldn't be :
${{ github.repository_owner }}/${{ fromJson(inputs.port_context).entity }} -> aka org-name/org-name/repo-name
but just: 
${{ fromJson(inputs.port_context).entity }} -> aka org-name/repo-name

## Updated docs pages

- https://docs.port.io/guides/all/create-cloud-resource-using-iac/

