### PR TITLE
PORT-14247 Updated datadog teams mapping relation to generate an array

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog/examples.md
@@ -757,7 +757,7 @@ resources:
             summary: .attributes.summary
             createdAt: .attributes.created_at | todate
           relations:
-            members: if .__members then .__members[].id else [] end
+            members: if .__members then [.__members[] | .id] else [] end
 ```
 
 </details>


### PR DESCRIPTION
# Description

This PR updates datadog teams mapping relation to generate an array o members correctly

## Added docs pages

Please also include the path for the added docs

- None

## Updated docs pages

Please also include the path for the updated docs

- Datadog example (`/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog/examples/#team`)
