### PR TITLE
PORT-14104 Add widget creation instruction to existing guides

### DIFF
--- a/docs/guides/all/ensure-production-readiness.md
+++ b/docs/guides/all/ensure-production-readiness.md
@@ -234,6 +234,83 @@ Now let's implement it:
 
     <img src='/img/guides/prodReadinessEntityAfterScorecard.png' width='100%' border='1px' />
 
+## Visualization
+By leveraging Port's Dashboards, you can create custom dashboards to track your production readiness metrics and monitor your services' compliance over time.
+
+<img src='/img/guides/productionReadinessOverview.png' border='1px' />
+
+### Dashboard setup
+
+<img src="/img/guides/productionReadinessDashboardComp.png" border="1px" />
+
+1. Go to your [software catalog](https://app.getport.io/organization/catalog).
+2. Click on the `+ New` button in the left sidebar.
+3. Select **New dashboard**.
+4. Name the dashboard (Production Readiness Metrics), choose an icon if desired, and click `Create`.
+
+This will create a new empty dashboard. Let's get ready-to-add widgets.
+
+### Adding widgets
+
+<details>
+<summary><b>Production Readiness Overview Widget (click to expand)</b></summary>
+
+1. Click `+ Widget` and select **Table**.
+2. Title: `Production Readiness Overview`, (add the `Production` icon).
+3. Select **Service** as the **Blueprint**.
+4. Show columns:
+   - Title
+   - Production Readiness Score
+   - On-call Status (pagerduty_oncall)
+   - Code Owner Review Status (require_code_owner_review)
+   - README Status (readme)
+5. Click on `Save`
+6. Click on the three dots on the widget and select `Customize table`.
+7. Click on the `Group by any Column` icon and select **Production Readiness**.
+8. Click on the `Save` icon.
+
+   <img src="/img/guides/productionReadinessOverview.png" width="50%" />
+
+</details>
+
+<details>
+<summary><b>On-call Coverage Widget (click to expand)</b></summary>
+
+1. Click `+ Widget` and select **Pie Chart**.
+2. Title: `On-call Coverage Distribution`, (add the `OnCall` icon).
+3. Select **Service** as the **Blueprint**.
+4. Choose `pagerduty_oncall` as the **Property**.
+5. Click on `Save`
+6. Click on the three dots on the widget and select `Customize chart`.
+7. Click on the `Group by any Column` icon and select **On-call Status**.
+8. Click on the `Save` icon.
+
+   <img src="/img/guides/oncallCoverageDistribution.png" width="50%" />
+
+</details>
+
+
+<details>
+<summary><b>Branch Protection Status Widget (click to expand)</b></summary>
+
+1. Click `+ Widget` and select **Table**.
+2. Title: `Branch Protection Status`, (add the `Branch` icon).
+3. Select **Service** as the **Blueprint**.
+4. Show columns:
+   - Title
+   - Required Approvals (required_approvals_for_pr)
+   - Code Owner Review Required (require_code_owner_review)
+5. Click on `Save`
+6. Click on the three dots on the widget and select `Customize table`.
+7. Click on the `Group by any Column` icon and select **Branch Protection Status**.
+8. Click on the `Save` icon.
+
+   <img src="/img/guides/branchProtectionStatus.png" width="50%" />
+
+</details>
+
+These widgets will give you a comprehensive view of your services' production readiness status, making it easy to identify areas that need attention.
+
 ## Possible daily routine integrations
 
 - Use Port's API to check for scorecard compliance from your CI and pass/fail it accordingly.

--- a/docs/guides/all/visualize-service-argocd-runtime.md
+++ b/docs/guides/all/visualize-service-argocd-runtime.md
@@ -198,28 +198,101 @@ To achieve this, we need to update the ArgoCD integration's mapping configuratio
 
     <br/>
 
-## Visualize data from your Kubernetes environment
+## Visualization
+By leveraging Port's Dashboards, you can create custom dashboards to track your ArgoCD runtime metrics and monitor your applications' performance over time.
 
-We now have a lot of data about our Argo applications, and a dashboard that visualizes it in ways that will benefit the routines of our developers and managers. Since our ArgoCD application(`workload`) blueprint is connected to our `service` blueprint, we can now access some of the application's data directly in the context of the service.  
-Let's see an example of how we can add useful visualizations to our dashboard:
+<img src='/img/guides/argocdRuntimeOverview.png' border='1px' />
 
-    
-### Display all degraded workloads for the `AwesomeService` service by team
+### Set up dashboard
 
-1. Go to your [ArgoCD dashboard](https://app.getport.io/argocdDashboard), click on the `+ Add` button in the top right corner, then select `Table`.
+<img src="/img/guides/argocdRuntimeDashboardComp.png" border="1px" />
 
-2. Fill the form out like this, then click `Save`:
+1. Go to your [software catalog](https://app.getport.io/organization/catalog).
+2. Click on the `+ New` button in the left sidebar.
+3. Select **New dashboard**.
+4. Name the dashboard (ArgoCD Runtime Metrics), choose an icon if desired, and click `Create`.
 
-    <img src='/img/guides/argoTableDegradedServicesForm.png' width='50%' border='1px' />
+This will create a new empty dashboard. Let's get ready-to-add widgets.
 
-3. In your new table, click on the `Filter` icon, then on `+ Add new filter`.  
-   Add three filters by filling out the fields like this:
+### Adding widgets
 
-    <img src='/img/guides/argoTableFilterDegraded.png' width='80%' border='1px' />
+<details>
+<summary><b>ArgoCD Sync Status Widget (click to expand)</b></summary>
 
-4. Your table should now display all services belonging to your specified team, whose `Health` is `Degraded`:
+1. Click `+ Widget` and select **Table**.
+2. Title: `ArgoCD Sync Status Overview`, (add the `ArgoCD` icon).
+3. Select **Workload** as the **Blueprint**.
+4. Show columns:
+   - Title
+   - Sync Status
+   - Health Status
+   - Last Synced
+   - Namespace
+5. Click on `Save`
+6. Click on the three dots on the widget and select `Customize table`.
+7. Click on the `Group by any Column` icon and select **Sync Status**.
+8. Click on the `Save` icon.
 
-    <img src='/img/guides/argoTableDegradedServices.png' width='90%' border='1px' />
+   <img src="/img/guides/argocdSyncStatusOverview.png" width="50%" />
+
+</details>
+
+<details>
+<summary><b>Sync History Widget (click to expand)</b></summary>
+
+1. Click `+ Widget` and select **Line Chart**.
+2. Title: `Sync History Trends`, (add the `History` icon).
+3. Select **Workload** as the **Blueprint**.
+4. Choose `Sync Status` and `Health Status` as the **Properties**.
+5. Select `day` for **Time interval**.
+6. Click on `Save`
+7. Click on the three dots on the widget and select `Customize chart`.
+8. Click on the `Group by any Column` icon and select **Workload**.
+9. Click on the `Save` icon.
+
+   <img src="/img/guides/syncHistoryTrends.png" width="50%" />
+
+</details>
+
+<details>
+<summary><b>Health Status Widget (click to expand)</b></summary>
+
+1. Click `+ Widget` and select **Pie Chart**.
+2. Title: `Application Health Distribution`, (add the `Health` icon).
+3. Select **Workload** as the **Blueprint**.
+4. Choose `Health Status` as the **Property**.
+5. Click on `Save`
+6. Click on the three dots on the widget and select `Customize chart`.
+7. Click on the `Group by any Column` icon and select **Namespace**.
+8. Click on the `Save` icon.
+
+   <img src="/img/guides/applicationHealthDistribution.png" width="50%" />
+
+</details>
+
+
+<details>
+<summary><b>Resource Status Widget (click to expand)</b></summary>
+
+1. Click `+ Widget` and select **Table**.
+2. Title: `Resource Status Overview`, (add the `Resources` icon).
+3. Select **Workload** as the **Blueprint**.
+4. Show columns:
+   - Title
+   - Resource Status
+   - Resource Health
+   - Resource Kind
+   - Namespace
+5. Click on `Save`
+6. Click on the three dots on the widget and select `Customize table`.
+7. Click on the `Group by any Column` icon and select **Resource Status**.
+8. Click on the `Save` icon.
+
+   <img src="/img/guides/resourceStatusOverview.png" width="50%" />
+
+</details>
+
+These widgets will give you a comprehensive view of your ArgoCD runtime, making it easy to monitor application health, sync status, and deployment progress across your cluster.
 
 ## Possible daily routine integrations
 

--- a/docs/guides/all/visualize-service-k8s-runtime.md
+++ b/docs/guides/all/visualize-service-k8s-runtime.md
@@ -221,6 +221,104 @@ To get an overall picture of our workloads' availability, we can use a table ope
 
 Note that you can also set this as the default view by click on the `Save this view` button 📝
 
+
+
+## Visualization
+By leveraging Port's Dashboards, you can create custom dashboards to track your Kubernetes runtime metrics and monitor your services' performance over time.
+
+<img src='/img/guides/k8sRuntimeOverview.png' border='1px' />
+
+### Dashboard setup
+
+<img src="/img/guides/k8sRuntimeDashboardComp.png" border="1px" />
+
+1. Go to your [software catalog](https://app.getport.io/organization/catalog).
+2. Click on the `+ New` button in the left sidebar.
+3. Select **New dashboard**.
+4. Name the dashboard (K8s Runtime Metrics), choose an icon if desired, and click `Create`.
+
+This will create a new empty dashboard. Let's get ready-to-add widgets.
+
+### Adding widgets
+
+<details>
+<summary><b>Service Health Overview Widget (click to expand)</b></summary>
+
+1. Click `+ Widget` and select **Table**.
+2. Title: `Service Health Overview`, (add the `Kubernetes` icon).
+3. Select **Workload** as the **Blueprint**.
+4. Show columns:
+   - Title
+   - Health Status
+   - Available Replicas
+   - Desired Replicas
+   - Namespace
+5. Click on `Save`
+6. Click on the three dots on the widget and select `Customize table`.
+7. Click on the `Group by any Column` icon and select **Health Status**.
+8. Click on the `Save` icon.
+
+   <img src="/img/guides/serviceHealthOverview.png" width="50%" />
+
+</details>
+
+<details>
+<summary><b>Resource Usage Widget (click to expand)</b></summary>
+
+1. Click `+ Widget` and select **Line Chart**.
+2. Title: `Resource Usage Trends`, (add the `Chart` icon).
+3. Select **Workload** as the **Blueprint**.
+4. Choose `CPU Usage` and `Memory Usage` as the **Properties**.
+5. Select `day` for **Time interval**.
+6. Click on `Save`
+7. Click on the three dots on the widget and select `Customize chart`.
+8. Click on the `Group by any Column` icon and select **Workload**.
+9. Click on the `Save` icon.
+
+   <img src="/img/guides/resourceUsageTrends.png" width="50%" />
+
+</details>
+
+
+<details>
+<summary><b>Namespace Distribution Widget (click to expand)</b></summary>
+
+1. Click `+ Widget` and select **Pie Chart**.
+2. Title: `Workload Distribution by Namespace`, (add the `Namespace` icon).
+3. Select **Workload** as the **Blueprint**.
+4. Choose `Namespace` as the **Property**.
+5. Click on `Save`
+6. Click on the three dots on the widget and select `Customize chart`.
+7. Click on the `Group by any Column` icon and select **Health Status**.
+8. Click on the `Save` icon.
+
+   <img src="/img/guides/namespaceDistribution.png" width="50%" />
+
+</details>
+
+<details>
+<summary><b>Resource Allocation Widget (click to expand)</b></summary>
+
+1. Click `+ Widget` and select **Table**.
+2. Title: `Resource Allocation Overview`, (add the `Resources` icon).
+3. Select **Workload** as the **Blueprint**.
+4. Show columns:
+   - Title
+   - CPU Request
+   - CPU Limit
+   - Memory Request
+   - Memory Limit
+5. Click on `Save`
+6. Click on the three dots on the widget and select `Customize table`.
+7. Click on the `Group by any Column` icon and select **Namespace**.
+8. Click on the `Save` icon.
+
+   <img src="/img/guides/resourceAllocationOverview.png" width="50%" />
+
+</details>
+
+These widgets will give you a comprehensive view of your Kubernetes runtime, making it easy to monitor service health, resource usage, and deployment status across your cluster.
+
 ## Possible daily routine integrations
 
 - Send a slack message in the R&D channel to let everyone know that a new deployment was created.


### PR DESCRIPTION

# Description

Add visualization guides for production readiness, ArgoCD runtime, and Kubernetes runtime metrics


## Updated docs pages

Please also include the path for the updated docs

- Visualize your services' k8s runtime (`/guides/all/visualize-service-k8s-runtime#visualization`)
- Visualize your services' Kubernetes runtime using ArgoCD (`/guides/all/visualize-service-argocd-runtime`)
- Ensure production readiness (`/guides/all/ensure-production-readiness`)
