### PR TITLE
Update local-debugging-webhook.md

### DIFF
--- a/docs/actions-and-automations/setup-backend/webhook/local-debugging-webhook.md
+++ b/docs/actions-and-automations/setup-backend/webhook/local-debugging-webhook.md
@@ -213,6 +213,7 @@ Here is the action JSON:
   "invocationMethod": {
     "type": "WEBHOOK",
     "url": "https://your-webhook-url.com",
+    "synchronized": true,
     "body": {
       "action": "{{ .action.identifier[(\"vm_\" | length):] }}",
       "resourceType": "run",
@@ -401,7 +402,7 @@ node index.js
 
 ## Triggering the action
 
-Login to port and go to the VM page and trigger the action via the **Create VM** action button:
+Login to Port and go to the VM page and trigger the action via the **Create VM** action button:
 
 ![Create VM button](/img/self-service-actions/CreateVMDropdown.png)
 
@@ -412,6 +413,8 @@ Fill the wanted details and click on `Create`
 And that's it, the `Success!` output shows that your local server really did receive your webhook payload:
 
 ![Webhook server response](/img/self-service-actions/HelloWorldLog.png)
+
+Since `synchronized` is set to `true` in the action JSON, the action's run status will also be updated to `Success` in Port. 
 
 :::tip
 Now that webhook requests are forwarded to your local machine, you can use your IDE to place breakpoints, examine the structure of the webhook request and iterate on your custom handler logic.


### PR DESCRIPTION
# Description
I added a line to the action JSON to account for request type in the invocation method (async, or sync) (no line for synchronization at all previously). While 'async' is the default, I found completing this guide confusing since I was seeing 'Success!' locally, but in Port's UI my run was listed as 'In Progress' perpetually. Adding "synchronized": true corrected this.

Then, added text to the end of the doc to clarify where the user can check the success of their action: "Since `synchronized` is set to `true` in the action JSON, the action's run status will also be updated to `Success` in Port."

## Updated docs pages

Please also include the path for the updated doc: 

/actions-and-automations/setup-backend/webhook/local-debugging-webhook
