### PR TITLE
fix incorrect regex from example

### DIFF
--- a/docs/guides/all/create-github-secret.md
+++ b/docs/guides/all/create-github-secret.md
@@ -43,7 +43,7 @@ Keep in mind this can be any blueprint you would like and this is just an exampl
         "title": "Secret Key",
         "type": "string",
         "description": "All Uppercase",
-        "pattern": "^[^a-z]*$"
+        "pattern": "[^a-z]*$"
       },
       "secret_value": {
         "icon": "Github",


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

valid secret names never meet regex requirement from doc.

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
![2025-05-21_19-54-39](https://github.com/user-attachments/assets/46c50466-e9f8-4955-9722-50c1cb855cd2)
