### PR TITLE
PORT-14793 Bug | To mention that Port Automations will not trigger upon deleting related entities

### DIFF
--- a/docs/actions-and-automations/define-automations/setup-trigger.md
+++ b/docs/actions-and-automations/define-automations/setup-trigger.md
@@ -91,8 +91,8 @@ The following trigger events are available for each type:
     </details>
 
     This automation will **not** be triggered in the following cases:
-    - When a related entity of a `developmentenv` entity is deleted (causing the relation to become null).
-    - When the source value of a `developmentenv` entity's mirror property changes.
+    - When a [related entity](/customize-pages-dashboards-and-plugins/page/entity-page#related-entities) of a `developmentenv` entity is deleted (causing the relation to become null).
+    - When the source value of a `developmentenv` entity's [mirror property](/build-your-software-catalog/customize-integrations/configure-data-model/setup-blueprint/properties/mirror-property) changes.
 
 ## Trigger JSON structure
 

--- a/docs/actions-and-automations/define-automations/setup-trigger.md
+++ b/docs/actions-and-automations/define-automations/setup-trigger.md
@@ -48,6 +48,52 @@ The following trigger events are available for each type:
   
   - When a [calculation property](/build-your-software-catalog/customize-integrations/configure-data-model/setup-blueprint/properties/calculation-property) based on a mirror property changes, the automation **will not** be triggered. 
 
+  - When a [related entity](/customize-pages-dashboards-and-plugins/page/entity-page#related-entities) is deleted, the automation **will not** be triggered on the entity that has a relation to the deleted entity.
+
+    <h3> Example scenario</h3>
+    Consider an automation that triggers when a `developmentenv` entity's `namespace` relation becomes null:
+
+    <details>
+    <summary><b>Example automation (click to expand)</b></summary>
+
+    ```json showLineNumbers
+    {
+      "identifier": "delete_developmentenv_entity_on_relation_change",
+      "title": "Delete developer env when namespace becomes null",
+      "trigger": {
+        "type": "automation",
+        "event": {
+          "type": "ANY_ENTITY_CHANGE",
+          "blueprintIdentifier": "developmentenv"
+        },
+        "condition": {
+          "type": "JQ",
+          "expressions": [
+            ".diff.after.relations.namespace == null",
+            ".diff.before.relations.namespace != null"
+          ],
+          "combinator": "and"
+        }
+      },
+      "invocationMethod": {
+        "type": "WEBHOOK",
+        "url": "https://api.getport.io/v1/blueprints/developmentenv/entities/{{ .event.context.entityIdentifier}}",
+        "synchronized": true,
+        "method": "DELETE",
+        "headers": {
+          "Content-type": "application/json",
+          "RUN_ID": "{{ .run.id }}"
+        }
+      },
+      "publish": true
+    }
+    ```
+    </details>
+
+    The above automation will **not** get triggered in either case:
+    - When a related entity of `developmentenv` blueprint is deleted (causing the relation to become null)
+    - When the source value of a `developmentenv` blueprint's mirror property changes
+
 ## Trigger JSON structure
 
 An automation's trigger is defined under the `trigger` key:

--- a/docs/actions-and-automations/define-automations/setup-trigger.md
+++ b/docs/actions-and-automations/define-automations/setup-trigger.md
@@ -90,9 +90,9 @@ The following trigger events are available for each type:
     ```
     </details>
 
-    The above automation will **not** get triggered in either case:
-    - When a related entity of `developmentenv` blueprint is deleted (causing the relation to become null)
-    - When the source value of a `developmentenv` blueprint's mirror property changes
+    This automation will **not** be triggered in the following cases:
+    - When a related entity of a `developmentenv` entity is deleted (causing the relation to become null).
+    - When the source value of a `developmentenv` entity's mirror property changes.
 
 ## Trigger JSON structure
 


### PR DESCRIPTION
# Description

Enhance automation trigger documentation with related entity deletion scenario and example. Clarified that automations will not trigger when a related entity is deleted or when a mirror property changes.

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- Setup triggers (`/actions-and-automations/define-automations/setup-trigger`)
