### PR TITLE
Add Merge Request Configuration Options

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
@@ -73,6 +73,55 @@ In the following example you will ingest your GitLab projects, their README.md f
 <MergeRequestConfig />
 </details>
 
+### Merge Request Configuration Options
+
+<Tabs groupId="config" queryString="parameter">
+
+<TabItem label="States" value="states">
+
+The `states` selector allows you to filter merge requests based on their state. You can specify one or more states to include in the sync.
+
+Allowed values:
+- `opened`: Merge requests that are currently open
+- `closed`: Merge requests that have been closed without merging
+- `merged`: Merge requests that have been merged
+
+By default, if not specified, only `opened` merge requests will be synced.
+
+```yaml
+  - kind: merge-request
+    selector:
+      query: 'true'
+      # highlight-next-line
+      states:
+        - merged
+        - opened
+```
+</TabItem>
+
+<TabItem label="Updated After" value="updatedAfter">
+
+The `updatedAfter` selector allows you to filter merge requests based on when they were last updated. This helps you focus on recent changes and reduce the amount of historical data being synced.
+
+The value represents the number of days to look back for merge requests. For example, setting it to `90` will only sync merge requests that have been updated in the last 90 days.
+
+:::note Important
+The `updatedAfter` parameter only affects merge requests that are not in the "opened" state. Open merge requests will always be synced regardless of their last update time.
+:::
+
+By default, if not specified, it is set to `90` days.
+
+```yaml
+  - kind: merge-request
+    selector:
+      query: 'true'
+      # highlight-next-line
+      updatedAfter: 90
+```
+</TabItem>
+
+</Tabs>
+
 :::tip Learn more
 - Refer to the [setup](/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/#setup) section to learn more about the integration configuration setup process.
 - We leverage [JQ JSON processor](https://stedolan.github.io/jq/manual/) to map and transform GitLab objects to Port entities.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
@@ -73,7 +73,7 @@ In the following example you will ingest your GitLab projects, their README.md f
 <MergeRequestConfig />
 </details>
 
-### Merge Request Configuration Options
+### Merge request configuration options
 
 <Tabs groupId="config" queryString="parameter">
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
@@ -82,9 +82,9 @@ In the following example you will ingest your GitLab projects, their README.md f
 The `states` selector allows you to filter merge requests based on their state. You can specify one or more states to include in the sync.
 
 Allowed values:
-- `opened`: Merge requests that are currently open
-- `closed`: Merge requests that have been closed without merging
-- `merged`: Merge requests that have been merged
+- `opened`: Merge requests that are currently open.
+- `closed`: Merge requests that have been closed without merging.
+- `merged`: Merge requests that have been merged.
 
 By default, if not specified, only `opened` merge requests will be synced.
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
@@ -105,7 +105,7 @@ The `updatedAfter` selector allows you to filter merge requests based on when th
 
 The value represents the number of days to look back for merge requests. For example, setting it to `90` will only sync merge requests that have been updated in the last 90 days.
 
-:::note Important
+:::info Important
 The `updatedAfter` parameter only affects merge requests that are not in the "opened" state. Open merge requests will always be synced regardless of their last update time.
 :::
 


### PR DESCRIPTION
# Description

This PR updates the GitLab merge request configuration documentation to accurately reflect the implementation of the `states` and `updatedAfter` parameters. The changes include:

- Added "Merge Request Configuration Options" section
- Added clear documentation about the allowed values for the newly introduced`states` and `updatedAfter` merge request selectors.
- Clarified that `updatedAfter` only affects non-opened merge requests
- Added proper section header for configuration options

## Updated docs pages

- GitLab v2 Examples (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md`)