### PR TITLE
Remove PagerDuty incident management guide from available guides list

### DIFF
--- a/src/components/guides-section/consts.js
+++ b/src/components/guides-section/consts.js
@@ -1251,13 +1251,6 @@ export const availableGuides = [
         link: "/guides/all/manage-and-visualize-ecs-tasks",
     },
     {
-        title: "Manage and visualize your PagerDuty incidents",
-        description: "Manage your PagerDuty incidents with self-service actions and create dashboards for visualization",
-        tags: ["Incident management", "PagerDuty", "Actions", "Dashboards"],
-        logos: ["PagerDuty"],
-        link: "/guides/all/manage-and-visualize-pagerduty-incidents",
-    },
-    {
         title: "Manage and visualize your AWS SQS queues",
         description: "Manage your AWS SQS queues with self-service actions and create dashboards for visualization",
         tags: ["Cloud access management", "AWS", "GitHub", "Dashboards"],


### PR DESCRIPTION

# Description

Remove PagerDuty incident management guide from available guides list to prevent duplication

Const file updated

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
