### PR TITLE
change prNumber to .number instead of .id

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/examples/_github_exporter_example_port_app_config.mdx
@@ -35,7 +35,7 @@ resources:
             updatedAt: ".updated_at"
             mergedAt: ".merged_at"
             createdAt: ".created_at"
-            prNumber: ".id"
+            prNumber: ".number"
             link: ".html_url"
             leadTimeHours: >-
                 (.created_at as $createdAt | .merged_at as $mergedAt |


### PR DESCRIPTION
# Description

Changed the mapping value for prNumber from .id to .number
Jira issue: https://getport.atlassian.net/browse/PORT-15060

## Updated docs pages

- https://docs.port.io/build-your-software-catalog/sync-data-to-catalog/git/github/examples/#map-repositories-and-pull-requests
