### PR TITLE
Port 12288 bug git hub user kind not accurate

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/_github_exporter_supported_resources.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/_github_exporter_supported_resources.mdx
@@ -16,4 +16,6 @@
 - [`tags`](https://docs.github.com/en/rest/repos/repos#list-repository-tags)
 
 
-**Note:** In regards to the `user` kind, only the `.name`, `.login` and `.email` fields are supported.
+**Note:** For the `user` kind, only the following fields are supported: `.name`, `.login`, and `.email`.  
+Other fields from the [GitHub User API](https://docs.github.com/en/rest/users/users#get-a-user) are not available.
+

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github/_github_exporter_supported_resources.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github/_github_exporter_supported_resources.mdx
@@ -15,3 +15,5 @@
 - [`releases`](https://docs.github.com/en/rest/releases/releases#list-releases)
 - [`tags`](https://docs.github.com/en/rest/repos/repos#list-repository-tags)
 
+
+**Note:** In regards to the `user` kind, only the `.name`, `.login` and `.email` fields are supported.


### PR DESCRIPTION
# Description

Added a note in regards to the `user` supported fields. 
Jira issue: https://getport.atlassian.net/browse/PORT-12288

## Updated docs pages

- https://docs.port.io/build-your-software-catalog/sync-data-to-catalog/git/github/#supported-resources
