### PR TITLE
add note of limitation on external video urls

### DIFF
--- a/docs/customize-pages-dashboards-and-plugins/dashboards/dashboards.md
+++ b/docs/customize-pages-dashboards-and-plugins/dashboards/dashboards.md
@@ -377,6 +377,8 @@ The widget also supports a wide variety of HTML tags, allowing you to create ric
 ```
 </details>
 
+**Note:** For external video URLs from providers such as YouTube, use the [iframe visualization widget](/customize-pages-dashboards-and-plugins/dashboards/#iframe-visualization).
+
 :::tip Practical example
 A practical example of using HTML in a markdown widget can be found in Port's [live demo](https://demo.getport.io/organization/home), in the `Catalog quick access` widget. 
 :::


### PR DESCRIPTION
# Description
inside markdown widget, the iframe tag and the video tag don't support external video urls like a youtube video url.
There was a bug opened about this but we don't want to allow it, so adding it explicitly in the docs, that it is allowed in the iframe.

Bug opened because of that: [14910](https://getport.atlassian.net/browse/PORT-14910)
Slack thread talking about not allowing this: https://getport.slack.com/archives/C06DQ1QR35L/p1750678475428669

## Updated docs pages

- docs/customize-pages-dashboards-and-plugins/dashboards/dashboards.md
