### PR TITLE
Bug | PORT-15315 Kubernetes integration is not mandatory in the terraform management guide

### DIFF
--- a/docs/guides/all/import-and-manage-integration.md
+++ b/docs/guides/all/import-and-manage-integration.md
@@ -13,16 +13,17 @@ import TabItem from "@theme/TabItem"
 
 # Manage integration mapping using Terraform
 
-In this example we'll use the Import State feature of Terraform, then manage our Port integration's mapping with Terraform.
+This guide demonstrates how to use the Import State feature of Terraform to manage your Port integration's mapping with Terraform.
+
 
 
 ## Prerequisites
+This guide assumes:
+- Complete the [onboarding process](/getting-started/overview).
+- You have the specific [integration](/integrations-index) you want to manage already installed in Port. 
 
-The [Kubernetes](/guides/all/visualize-service-k8s-runtime) integration needs to be installed.
-
-
-:::info  Installation Id
-Take note of the installation Id of the Kubernetes integration when installing it.
+:::info Installation Id
+Take note of the installation ID of your integration when installing it - you'll need this ID to import and manage the integration with Terraform.
 :::
 
 

--- a/docs/guides/all/import-and-manage-integration.md
+++ b/docs/guides/all/import-and-manage-integration.md
@@ -18,9 +18,9 @@ This guide demonstrates how to use the Import State feature of Terraform to mana
 
 
 ## Prerequisites
-This guide assumes:
+
 - Complete the [onboarding process](/getting-started/overview).
-- You have the specific [integration](/integrations-index) you want to manage already installed in Port. 
+- Install the [integration](/integrations-index) whose mapping you want to manage. 
 
 :::info Installation Id
 Take note of the installation ID of your integration when installing it - you'll need this ID to import and manage the integration with Terraform.


### PR DESCRIPTION

# Description

Update Terraform integration guide to clarify usage of Import State feature and prerequisites


## Updated docs pages

Please also include the path for the updated docs

- Manage integration mapping using Terraform (`/guides/all/import-and-manage-integration`)
