### PR TITLE
deleted svg from the supported html tags

### DIFF
--- a/docs/customize-pages-dashboards-and-plugins/dashboards/dashboards.md
+++ b/docs/customize-pages-dashboards-and-plugins/dashboards/dashboards.md
@@ -376,7 +376,6 @@ The widget also supports a wide variety of HTML tags, allowing you to create ric
 'wbr',
 'img',
 'video',
-'svg',
 'caption',
 'col',
 'colgroup',


### PR DESCRIPTION
# Description

As per this JIRA issue: https://getport.atlassian.net/browse/PORT-15626
I deleted the 'svg' from the supported html tags

## Updated docs pages

- https://docs.port.io/customize-pages-dashboards-and-plugins/dashboards/#markdown