### PR TITLE
Updated Docs for Datadog Service Dependency integration

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog/examples.md
@@ -777,45 +777,19 @@ resources:
   "title": "Datadog Service Dependency",
   "icon": "Datadog",
   "schema": {
-    "properties": {
-      "sourceService": {
-        "type": "string",
-        "title": "Source Service",
-        "description": "The service that is making the call (depends on other services)"
-      },
-      "calledServices": {
-        "type": "array",
-        "title": "Called Services",
-        "description": "List of services that are called by the source service",
-        "items": {
-          "type": "string"
-        }
-      },
-      "description": {
-        "type": "string",
-        "title": "Description",
-        "description": "A description of the dependency relationship"
-      }
-    },
-    "required": ["sourceService"]
+    "properties": {},
+    "required": []
   },
   "mirrorProperties": {},
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "source": {
+    "dependencies": {
+      "title": "Depends on",
+      "description": "The services called by the source service",
       "target": "datadogService",
-      "title": "Source Service",
-      "description": "The service that is making the call",
-      "many": false,
-      "required": true
-    },
-    "targets": {
-      "target": "datadogService",
-      "title": "Called Services",
-      "description": "The services that are called by the source service",
-      "many": true,
-      "required": false
+      "required": false,
+      "many": true
     }
   }
 }
@@ -832,20 +806,19 @@ createMissingRelatedEntities: true
 resources:
   - kind: serviceDependency
     selector:
-      query: "true"
+      query: 'true'
+      environment: 'dev'
+      startTime: 1
     port:
       entity:
         mappings:
-          identifier: .sourceService
-          title: .sourceService
+          identifier: .name | tostring
+          title: .name
           blueprint: '"datadogServiceDependency"'
           properties:
-            sourceService: .sourceService
-            calledServices: .calledServices
-            description: .description
+            sourceService: .name
           relations:
-            source: .sourceService
-            targets: .calledServices
+            dependencies: '[.calls[] | tostring]'
 ```
 
 </details>


### PR DESCRIPTION
# Description

This is docs for the Datadog Service Dependency integration powered by Ocean framework.

## Added docs pages

- Datadog Ocean (`/build-your-software-catalog/sync-data-to-catalog/git/datadog-ocean/`)
- Installation (`/build-your-software-catalog/sync-data-to-catalog/git/datadog-ocean/installation`)
- Self-hosted app installation (`/build-your-software-catalog/sync-data-to-catalog/git/datadog-ocean/self-hosted-installation`)
- Examples (`/build-your-software-catalog/sync-data-to-catalog/git/datadog-ocean/examples/resource-mapping-examples`)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
