### PR TITLE
Add a prerequisite to Snyk docs

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
@@ -37,7 +37,7 @@ The resources that can be ingested from Snyk into Port are listed below. It is p
 2. A port organization with admin role
 
 :::note Snyk Enterprise
-Personal tokens from Snyk Free and Snyk Team plans can not be used with Snyk API. [Learn More](https://docs.snyk.io/snyk-api/authentication-for-api) #Ai! improve this
+The Snyk API is available for Enterprise customers only. Authentication using personal tokens from Snyk Free or Team plans is not supported. [Learn More](https://docs.snyk.io/snyk-api/authentication-for-api)
 :::
 
 Choose one of the following installation methods:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
@@ -33,11 +33,11 @@ The resources that can be ingested from Snyk into Port are listed below. It is p
 
 ### Prerequisites
 
-1. A Snyk enterprise account
-2. A port organization with admin role
+1. A Snyk enterprise account.
+2. A port organization with admin permissions.
 
-:::note Snyk Enterprise
-The Snyk API is available for Enterprise customers only. Authentication using personal tokens from Snyk Free or Team plans is not supported. [Learn More](https://docs.snyk.io/snyk-api/authentication-for-api)
+:::info Snyk Enterprise
+The Snyk API is available for Enterprise customers only. Authentication using personal tokens from Snyk Free or Team plans is not supported. [Learn More](https://docs.snyk.io/snyk-api/authentication-for-api).
 :::
 
 Choose one of the following installation methods:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
@@ -31,6 +31,15 @@ The resources that can be ingested from Snyk into Port are listed below. It is p
 
 ## Setup
 
+### Prerequisites
+
+1. A Snyk enterprise account
+2. A port organization with admin role
+
+:::note Snyk Enterprise
+Personal tokens from Snyk Free and Snyk Team plans can not be used with Snyk API. [Learn More](https://docs.snyk.io/snyk-api/authentication-for-api) #Ai! improve this
+:::
+
 Choose one of the following installation methods:
 
 <Tabs groupId="installation-methods" queryString="installation-methods">

--- a/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/snyk.md
@@ -34,7 +34,7 @@ The resources that can be ingested from Snyk into Port are listed below. It is p
 ### Prerequisites
 
 1. A Snyk enterprise account.
-2. A port organization with admin permissions.
+2. A Port organization with admin permissions.
 
 :::info Snyk Enterprise
 The Snyk API is available for Enterprise customers only. Authentication using personal tokens from Snyk Free or Team plans is not supported. [Learn More](https://docs.snyk.io/snyk-api/authentication-for-api).


### PR DESCRIPTION
# Description

New Relic investigation on Snyk shows a lot of 401 unauthorized errors, my investigations shows this is likely due to customers attempting to install the integration with non-enterprise Snyk accounts where the API is not available, this clarifies that a Snyk enterprise account is necessary, along with relevant link.

## Updated docs pages

Please also include the path for the updated docs

- Snyk (`/build-your-software-catalog/sync-data-to-catalog/code-quality-security/snyk/`)
