### PR TITLE
Fix Azure DevOps documentation service blueprint descrapenies

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_monorepo_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_monorepo_port_app_config.mdx
@@ -18,8 +18,8 @@ resources:
         mappings:
           identifier: .objectId
           title: .path
-          url: .__repository.url
-          blueprint: '"azureDevopsRepository"'
+          url: .__repository.remoteUrl
+          blueprint: '"service"'
           properties:
             defaultBranch: .__repository.defaultBranch
           relations:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_port_app_config.mdx
@@ -26,11 +26,12 @@ resources:
     port:
       entity:
         mappings:
-          identifier: "\(.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.name | ascii_downcase | gsub("[ ();]"; ""))"
+          identifier: >-
+            "\(.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.name | ascii_downcase | gsub("[ ();]"; ""))"
           title: .name
-          blueprint: '"azureDevopsRepository"'
+          blueprint: '"service"'
           properties:
-            url: .url
+            url: .remoteUrl
             readme: file://README.md
           relations:
             project: .project.id | gsub(" "; "")
@@ -40,8 +41,9 @@ resources:
     port:
       entity:
         mappings:
-          identifier: '.__repository.project.name + "/" + .__repository.name | gsub(" "; "")'
-          blueprint: '"azureDevopsRepository"'
+          identifier: >-
+            "\(.__repository.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.__repository.name | ascii_downcase | gsub("[ ();]"; ""))"
+          blueprint: '"service"'
           properties:
             minimumApproverCount: .settings.minimumApproverCount
   - kind: repository-policy
@@ -50,8 +52,9 @@ resources:
     port:
       entity:
         mappings:
-          identifier: '.__repository.project.name + "/" + .__repository.name | gsub(" "; "")'
-          blueprint: '"azureDevopsRepository"'
+          identifier: >-
+            "\(.__repository.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.__repository.name | ascii_downcase | gsub("[ ();]"; ""))"
+          blueprint: '"service"'
           properties:
             workItemLinking: .isEnabled and .isBlocking
   - kind: pull-request
@@ -61,13 +64,10 @@ resources:
       entity:
         mappings:
           identifier: >-
-            .repository.project.name + "/" + .repository.name + (.pullRequestId
-            | tostring) | gsub(" "; "")
+            "\(.repository.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.repository.name | ascii_downcase | gsub("[ ();]"; ""))/\(.pullRequestId | tostring)"
           blueprint: '"azureDevopsPullRequest"'
           properties:
-            creator: .createdBy.uniqueName
             status: .status
-            reviewers: '[.reviewers[].uniqueName]'
             createdAt: .creationDate
             leadTimeHours: >-
               (.creationDate as $createdAt | .status as $status | .closedDate as $closedAt |
@@ -78,7 +78,10 @@ resources:
               (((($closedTimestamp - $createdTimestamp) / 3600) * 100 | floor) / 100)
               else null end)
           relations:
-            repository: '.repository.project.name + "/" + .repository.name | gsub(" "; "")'
+            service: >-
+              "\(.repository.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.repository.name | ascii_downcase | gsub("[ ();]"; ""))"
+            creator: .createdBy.uniqueName
+            reviewers: '[.reviewers[].uniqueName]'
 ```
 
 </details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_pull_request_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_pull_request_blueprint.mdx
@@ -8,10 +8,6 @@
   "icon": "AzureDevops",
   "schema": {
     "properties": {
-      "creator": {
-        "title": "Creator",
-        "type": "string"
-      },
       "status": {
         "title": "Status",
         "type": "string",
@@ -24,14 +20,6 @@
           "completed": "yellow",
           "abandoned": "red",
           "active": "green"
-        }
-      },
-      "reviewers": {
-        "type": "array",
-        "title": "Reviewers",
-        "items": {
-          "type": "string",
-          "format": "user"
         }
       },
       "createdAt": {
@@ -55,11 +43,23 @@
   "calculationProperties": {},
   "aggregationProperties": {},
   "relations": {
-    "repository": {
-      "title": "Repository",
-      "target": "azureDevopsRepository",
+    "service": {
+      "title": "Service",
+      "target": "service",
       "required": false,
       "many": false
+    },
+    "creator": {
+      "title": "Creator",
+      "target": "azureDevopsUser",
+      "required": false,
+      "many": false
+    },
+    "reviewers": {
+      "title": "Reviewers",
+      "target": "azureDevopsUser",
+      "required": false,
+      "many": true
     }
   }
 }

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_repository_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_repository_blueprint.mdx
@@ -3,8 +3,8 @@
 
 ```json showLineNumbers
   {
-    "identifier": "azureDevopsRepository",
-    "title": "Repository",
+    "identifier": "service",
+    "title": "Service",
     "icon": "AzureDevops",
     "schema": {
       "properties": {

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops.md
@@ -53,7 +53,7 @@ resources:
     entity:
       mappings:
         identifier: .id | gsub(" "; "")
-        blueprint: '"azureDevopsProject"'
+        blueprint: '"project"'
         title: .name
         properties:
           state: .state
@@ -67,11 +67,12 @@ resources:
   port:
     entity:
       mappings:
-        identifier: .project.name + "/" + .name | gsub(" "; "")
+        identifier: >-
+          "\(.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.name | ascii_downcase | gsub("[ ();]"; ""))"
         title: .name
-        blueprint: '"azureDevopsRepository"'
+        blueprint: '"service"'
         properties:
-          url: .url
+          url: .remoteUrl
           readme: file://README.md
           id: .id
           last_activity: .project.lastUpdateTime
@@ -83,8 +84,9 @@ resources:
   port:
     entity:
       mappings:
-        identifier: .__repository.project.name + "/" + .__repository.name | gsub(" "; "")
-        blueprint: '"azureDevopsRepository"'
+        identifier: >-
+          "\(.__repository.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.__repository.name | ascii_downcase | gsub("[ ();]"; ""))"
+        blueprint: '"service"'
         properties:
           minimumApproverCount: .settings.minimumApproverCount
 - kind: repository-policy
@@ -93,8 +95,9 @@ resources:
   port:
     entity:
       mappings:
-        identifier: .__repository.project.name + "/" + .__repository.name | gsub(" "; "")
-        blueprint: '"azureDevopsRepository"'
+        identifier: >-
+          "\(.__repository.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.__repository.name | ascii_downcase | gsub("[ ();]"; ""))"
+        blueprint: '"service"'
         properties:
           workItemLinking: .isEnabled and .isBlocking
 - kind: user
@@ -131,7 +134,8 @@ resources:
   port:
     entity:
       mappings:
-        identifier: .repository.project.name + "/" + .repository.name + (.pullRequestId | tostring) | gsub(" "; "")
+        identifier: >-
+          "\(.repository.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.repository.name | ascii_downcase | gsub("[ ();]"; ""))/\(.pullRequestId | tostring)"
         blueprint: '"azureDevopsPullRequest"'
         properties:
           status: .status
@@ -159,11 +163,6 @@ resources:
               value: '[.reviewers[].uniqueName]'
           azure_devops_reviewers: '[.reviewers[].id]'
           azure_devops_creator: .createdBy.id
-
-
-
-
-
 ```
 
 </details>
@@ -469,9 +468,9 @@ The combination of the sample payload and the Ocean configuration generates the 
 
 ```json showLineNumbers
 {
-  "identifier": "PortIntegration/final_project_to_project_test",
+  "identifier": "portintegration/final_project_to_project_test",
   "title": "final_project_to_project_test",
-  "blueprint": "azureDevopsRepository",
+  "blueprint": "service",
   "properties": {
     "url": "[REDACTED]/fd029361-7854-4cdd-8ace-bb033fca399c/_apis/git/repositories/43c319c8-5adc-41f8-8486-745fe2130cd6",
     "readme": "<README.md Content>",

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-teams/_azuredevops_exporter_example_teams_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-teams/_azuredevops_exporter_example_teams_port_app_config.mdx
@@ -26,11 +26,12 @@ resources:
     port:
       entity:
         mappings:
-          identifier: '.project.name + "/" + .name | gsub(" "; "")'
+          identifier: >-
+            "\(.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.name | ascii_downcase | gsub("[ ();]"; ""))"
           title: .name
-          blueprint: '"azureDevopsRepository"'
+          blueprint: '"service"'
           properties:
-            url: .url
+            url: .remoteUrl
             readme: file://README.md
           relations:
             project: .project.id | gsub(" "; "")
@@ -40,8 +41,9 @@ resources:
     port:
       entity:
         mappings:
-          identifier: '.__repository.project.name + "/" + .__repository.name | gsub(" "; "")'
-          blueprint: '"azureDevopsRepository"'
+          identifier: >-
+            "\(.__repository.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.__repository.name | ascii_downcase | gsub("[ ();]"; ""))"
+          blueprint: '"service"'
           properties:
             minimumApproverCount: .settings.minimumApproverCount
   - kind: repository-policy
@@ -50,8 +52,9 @@ resources:
     port:
       entity:
         mappings:
-          identifier: '.__repository.project.name + "/" + .__repository.name | gsub(" "; "")'
-          blueprint: '"azureDevopsRepository"'
+          identifier: >-
+            "\(.__repository.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.__repository.name | ascii_downcase | gsub("[ ();]"; ""))"
+          blueprint: '"service"'
           properties:
             workItemLinking: .isEnabled and .isBlocking
   - kind: team

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md
@@ -37,11 +37,12 @@ To do so, we will use the `file://` prefix with the path of the file to tell the
     port:
       entity:
         mappings:
-          identifier: .project.name + "/" + .name
+          identifier: >-
+            "\(.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.name | ascii_downcase | gsub("[ ();]"; ""))"
           title: .name
-          blueprint: '"azureDevopsRepository"'
+          blueprint: '"service"'
           properties:
-            url: .url
+            url: .remoteUrl
             // highlight-next-line
             readme: file://README.md
 ```

--- a/docs/getting-started/set-up-automatic-discovery.md
+++ b/docs/getting-started/set-up-automatic-discovery.md
@@ -230,11 +230,17 @@ Once you have done this, you can add the following block to the mapping configur
   port:
     entity:
       mappings:
-        identifier: .project.name + "/" + .name | gsub(" "; "")
+        identifier: >-
+          "\(.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.name | ascii_downcase | gsub("[ ();]"; ""))"
         title: .name
         blueprint: '"service"'
+        properties:
+          url: .remoteUrl
+          readme: file://README.md
+          defaultBranch: .defaultBranch
         relations:
-          azureDevopsRepository: .project.name + "/" + .name | gsub(" "; "")
+          service: >-
+            "\(.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.name | ascii_downcase | gsub("[ ();]"; ""))"
 ```
 </details>
 

--- a/docs/guides/all/copy-pipeline-template-to-target-repo.md
+++ b/docs/guides/all/copy-pipeline-template-to-target-repo.md
@@ -53,8 +53,8 @@ First, let's set up the necessary Azure DevOps components to handle the pipeline
     
     ```json showLineNumbers
     {
-      "identifier": "azureDevopsRepository",
-      "title": "Repository",
+      "identifier": "service",
+      "title": "Service",
       "icon": "AzureDevops",
       "schema": {
         "properties": {
@@ -103,11 +103,12 @@ First, let's set up the necessary Azure DevOps components to handle the pipeline
         port:
           entity:
             mappings:
-              identifier: .project.name + "/" + .name | gsub(" "; "")
+              identifier: >-
+                "\(.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.name | ascii_downcase | gsub("[ ();]"; ""))"
               title: .name
-              blueprint: '"azureDevopsRepository"'
+              blueprint: '"service"'
               properties:
-                url: .url
+                url: .remoteUrl
                 readme: file://README.md
                 defaultBranch: .defaultBranch # Add this line
               relations:

--- a/docs/guides/all/scaffold-a-new-service.md
+++ b/docs/guides/all/scaffold-a-new-service.md
@@ -1108,7 +1108,7 @@ stages:
                       "project":"${{ variables.PROJECT_ID }}"
                     }
                   }' \
-                "https://api.getport.io/v1/blueprints/azureDevopsRepository/entities?upsert=true&run_id=${{ variables.RUN_ID }}&create_missing_related_entities=true"
+                "https://api.getport.io/v1/blueprints/service/entities?upsert=true&run_id=${{ variables.RUN_ID }}&create_missing_related_entities=true"
               
   - stage: upsert_service
     dependsOn:
@@ -1134,7 +1134,7 @@ stages:
                       "description":"${{ variables.DESCRIPTION }}"
                     },
                     "relations": {
-                      "azureDevopsRepository": "${{ variables.SERVICE_NAME }}"
+                      "service": "${{ variables.SERVICE_NAME }}"
                     }
                   }' \
                 "https://api.getport.io/v1/blueprints/service/entities?upsert=true&run_id=${{ variables.RUN_ID }}&create_missing_related_entities=true"    

--- a/docs/guides/all/scaffold-repositories-using-cookiecutter.md
+++ b/docs/guides/all/scaffold-repositories-using-cookiecutter.md
@@ -93,8 +93,8 @@ However, we highly recommend you install the Azure DevOps integration to have th
 
     ```json showLineNumbers
     {
-      "identifier": "azureDevopsRepository",
-      "title": "Azure DevOps Repository",
+      "identifier": "service",
+      "title": "Service",
       "icon": "Azure",
       "schema": {
         "properties": {
@@ -119,6 +119,7 @@ However, we highly recommend you install the Azure DevOps integration to have th
       },
       "mirrorProperties": {},
       "calculationProperties": {},
+      "aggregationProperties": {},
       "relations": {}
     }
     ```
@@ -203,7 +204,7 @@ However, we highly recommend you install the Azure DevOps integration to have th
           
           ]
         },
-        "blueprintIdentifier": "azureDevopsRepository"
+        "blueprintIdentifier": "service"
       },
       "invocationMethod": {
         "type": "AZURE_DEVOPS",


### PR DESCRIPTION
# Description

This PR aligns Azure DevOps integration documentation with the standardized format used across Port's integrations. The changes ensure consistency in blueprint identifiers, property mappings, and identifier formats, making the documentation more maintainable and reducing confusion for users implementing Azure DevOps integrations.

## Motivation and Context

The Azure DevOps documentation previously used inconsistent blueprint naming (`azureDevopsRepository` vs `service`) and property mappings (`.url` vs `.remoteUrl`). 

## Updated docs pages

- Azure DevOps Integration (`/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops.md`)
- Azure DevOps Examples (`/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md`)
- Azure DevOps Mapping Extensions (`/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md`)
- Azure DevOps Example Configurations:
  - Port App Config (`/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_port_app_config.mdx`)
  - Monorepo Config (`/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_monorepo_port_app_config.mdx`)
  - Teams Config (`/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-teams/_azuredevops_exporter_example_teams_port_app_config.mdx`)
- Azure DevOps Blueprint Definitions:
  - Repository Blueprint (`/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_repository_blueprint.mdx`)
  - Pull Request Blueprint (`/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_example_pull_request_blueprint.mdx`)
- Getting Started - Set up automatic discovery (`/getting-started/set-up-automatic-discovery.md`)
- Azure DevOps Guides:
  - Copy Pipeline Template (`/guides/all/copy-pipeline-template-to-target-repo.md`)
  - Scaffold a New Service (`/guides/all/scaffold-a-new-service.md`)
  - Scaffold Repositories Using Cookiecutter (`/guides/all/scaffold-repositories-using-cookiecutter.md`)