### PR TITLE
Fix Azure DevOps Documentation for Pipeline and Repository Relationship

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops.md
@@ -589,6 +589,40 @@ Common scenarios for file mapping include:
 Click [here](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/get?view=azure-devops-rest-7.1&tabs=HTTP#download) for the Azure DevOps file object structure.
 :::
 
+### Linking Pipelines to Repositories via Selector
+You can configure your selector to include repository information in the pipeline entity mapping.
+This allows you to create a direct relationship between a pipeline and its source repository.
+
+```yaml showLineNumbers
+- kind: pipeline
+  selector:
+    query: 'true'
+    includeRepo: 'true'
+  port:
+    entity:
+      mappings:
+        identifier: .id | tostring
+        title: .name
+        blueprint: '"azureDevOpsPipeline"'
+        properties:
+          url: .url
+          revision: .revision
+          folder: .folder
+        relations:
+          project: .__projectId | gsub(" "; "")
+          repository: >-
+            if .__repository
+            then .__repository.project.name + "/" + .__repository.name | gsub(" "; "")
+            else null
+            end
+```
+:::tip Recommendation
+Use this only when necessary, as including repository data requires an extra API call per pipeline, which increases the number of requests made and can impact your Azure DevOps API rate limits.
+
+If you don’t require repo-level linkage, it’s more efficient to relate pipelines → projects instead.
+:::
+
+
 ## Examples
 
 Refer to the [examples](./examples.md) page for practical configurations and their corresponding blueprint definitions.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops.md
@@ -589,40 +589,6 @@ Common scenarios for file mapping include:
 Click [here](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/get?view=azure-devops-rest-7.1&tabs=HTTP#download) for the Azure DevOps file object structure.
 :::
 
-### Linking Pipelines to Repositories via Selector
-You can configure your selector to include repository information in the pipeline entity mapping.
-This allows you to create a direct relationship between a pipeline and its source repository.
-
-```yaml showLineNumbers
-- kind: pipeline
-  selector:
-    query: 'true'
-    includeRepo: 'true'
-  port:
-    entity:
-      mappings:
-        identifier: .id | tostring
-        title: .name
-        blueprint: '"azureDevOpsPipeline"'
-        properties:
-          url: .url
-          revision: .revision
-          folder: .folder
-        relations:
-          project: .__projectId | gsub(" "; "")
-          repository: >-
-            if .__repository
-            then .__repository.project.name + "/" + .__repository.name | gsub(" "; "")
-            else null
-            end
-```
-:::tip Recommendation
-Use this only when necessary, as including repository data requires an extra API call per pipeline, which increases the number of requests made and can impact your Azure DevOps API rate limits.
-
-If you don’t require repo-level linkage, it’s more efficient to relate pipelines → projects instead.
-:::
-
-
 ## Examples
 
 Refer to the [examples](./examples.md) page for practical configurations and their corresponding blueprint definitions.

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md
@@ -55,6 +55,7 @@ This allows you to create a direct relationship between a pipeline and its sourc
 - kind: pipeline
   selector:
     query: 'true'
+    # highlight-next-line
     includeRepo: 'true'
   port:
     entity:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md
@@ -47,7 +47,7 @@ To do so, we will use the `file://` prefix with the path of the file to tell the
             readme: file://README.md
 ```
 
-## Linking Pipelines to Repositories via Selector
+## Link pipelines to repositories via selector
 You can configure your selector to include repository information in the pipeline entity mapping.
 This allows you to create a direct relationship between a pipeline and its source repository.
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/mapping_extensions.md
@@ -46,3 +46,36 @@ To do so, we will use the `file://` prefix with the path of the file to tell the
             // highlight-next-line
             readme: file://README.md
 ```
+
+## Linking Pipelines to Repositories via Selector
+You can configure your selector to include repository information in the pipeline entity mapping.
+This allows you to create a direct relationship between a pipeline and its source repository.
+
+```yaml showLineNumbers
+- kind: pipeline
+  selector:
+    query: 'true'
+    includeRepo: 'true'
+  port:
+    entity:
+      mappings:
+        identifier: .id | tostring
+        title: .name
+        blueprint: '"azureDevOpsPipeline"'
+        properties:
+          url: .url
+          revision: .revision
+          folder: .folder
+        relations:
+          project: .__projectId | gsub(" "; "")
+          repository: >-
+            if .__repository
+            then .__repository.project.name + "/" + .__repository.name | gsub(" "; "")
+            else null
+            end
+```
+:::tip Recommendation
+Use this only when necessary, as including repository data requires an extra API call per pipeline, which increases the number of requests made and can impact your Azure DevOps API rate limits.
+
+If you don’t require repo-level linkage, it’s more efficient to relate pipelines → projects instead.
+:::


### PR DESCRIPTION
## Description
Added Documention for selector configuration to include repository information for pipelines, enabling direct pipeline→repository relationships.

## Motivation and Context
Needed for cases where repo-level linkage is required; disabled by default due to extra API calls and potential rate limit impact.

## Added docs pages

Please also include the path for the added docs
/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/azure-devops
- ...
