### PR TITLE
Added a link to swagger in the API pages

### DIFF
--- a/docs/api-reference/pages.mdx
+++ b/docs/api-reference/pages.mdx
@@ -6,6 +6,8 @@
 
 Port API's `pages` endpoints will undergo a structural change in the near future. The new structure will be more intuitive and easier to use.
 
+Until the new structure is released, you can refer to the [Swagger API documentation](https://api.port.io/swagger/#Pages) for the available endpoints and their usage.
+
 Currently, the `pages` endpoints allow you to:
 
 - **Create**, **update**, **delete**, and **get** pages.


### PR DESCRIPTION
# Description

Added a link to swagger on the API pages page.

## Updated docs pages

- https://docs.port.io/api-reference/pages