### PR TITLE
Improve identifier mapping logic for Bitbucket Server integration

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/bitbucket-server/bitbucket-server.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/bitbucket-server/bitbucket-server.md
@@ -779,7 +779,7 @@ resources:
     port:
       entity:
         mappings:
-          identifier: .id | tostring
+          identifier: (.toRef.repository.slug // .toRef.repository.project.key) + "-" + (.id|tostring)
           title: .title
           blueprint: '"bitbucketPullRequest"'
           properties:


### PR DESCRIPTION
# Description

Fixed issue where pull requests in the Bitbucket Server integration were not unique across multiple repositories during data ingestion.

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

docs/build-your-software-catalog/sync-data-to-catalog/git/bitbucket/bitbucket-server/bitbucket-server.md

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
