### PR TITLE
Update Repository Relations as List in GitHub Ocean

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github-ocean/examples/example-repository-collaborators/_github_exporter_example_repository_collaborator_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github-ocean/examples/example-repository-collaborators/_github_exporter_example_repository_collaborator_port_app_config.mdx
@@ -8,6 +8,7 @@ resources:
   - kind: repository
     selector:
       query: "true" # JQ boolean query. If evaluated to false - skip syncing the object.
+      include: ["collaborators"] # Include collaborators as a relationship
     port:
       entity:
         mappings:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github-ocean/examples/example-repository-teams/_github_exporter_example_repository_with_teams_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github-ocean/examples/example-repository-teams/_github_exporter_example_repository_with_teams_port_app_config.mdx
@@ -25,7 +25,7 @@ resources:
   - kind: repository
     selector:
       query: "true" # JQ boolean query. If evaluated to false - skip syncing the object.
-      include: "teams" # Boolean flag to indicate whether to include the repository teams.
+      include: ["teams"] # List of relationship types to include. Can include multiple types like ["teams", "collaborators"].
     port:
       entity:
         mappings:

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/github-ocean/examples/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/github-ocean/examples/examples.md
@@ -199,6 +199,57 @@ You can use the following Port blueprint definitions and `port-app-config.yml`:
 <PortRepositoryTeamMappingAppConfig/>
 
 
+## Map repositories with multiple relationships
+
+You can now include multiple relationship types in a single repository configuration. For example, to include both teams and collaborators:
+
+```yaml showLineNumbers
+- kind: repository
+  selector:
+    query: "true"
+    include: ["teams", "collaborators"] # Include both teams and collaborators
+  port:
+    entity:
+      mappings:
+        identifier: .name
+        title: .name
+        blueprint: '"githubRepository"'
+        properties:
+          readme: file://README.md
+          url: .html_url
+          defaultBranch: .default_branch
+        relations:
+          githubTeams: "[.__teams[].id | tostring]"
+          githubCollaborators: "[.__collaborators[].login]"
+```
+
+:::caution Performance consideration
+While you can include multiple relationship types in a single configuration, this may impact resync performance for large repositories. For optimal performance, consider separating into multiple repository blocks:
+
+```yaml showLineNumbers
+# Option 1: Separate blocks for better performance
+- kind: repository
+  selector:
+    query: "true"
+    include: ["teams"]
+  # ... rest of configuration
+
+- kind: repository  
+  selector:
+    query: "true"
+    include: ["collaborators"]
+  # ... rest of configuration
+
+# Option 2: Single block with multiple relationships
+- kind: repository
+  selector:
+    query: "true"
+    include: ["teams", "collaborators"]
+  # ... rest of configuration
+```
+:::
+
+
 ## Map teams and team members
 
 The following shows how we can map teams and team members using the "members" selector.


### PR DESCRIPTION
# Description

## Summary of Changes
Updated the GitHub Ocean integration documentation to reflect the new list-based `include` selector functionality that supports multiple relationship types simultaneously. This change allows users to specify both "teams" and "collaborators" in a single repository configuration instead of being limited to one relationship type at a time.

## Issue Fixed
Enhanced the GitHub integration documentation to accurately represent the new functionality that supports multiple relationship types in the `include` selector, providing users with better guidance on configuration options and performance considerations.

## Motivation and Context
The GitHub Ocean integration was recently updated to support multiple relationship types (teams and collaborators) in a single configuration block. The documentation needed to be updated to:
- Show the new list-based syntax: `include: ["teams", "collaborators"]`
- Provide examples of how to use multiple relationship types
- Include performance optimization recommendations for large repositories
- Maintain backward compatibility while showcasing new capabilities

## Added docs pages

No new documentation pages were added.

## Updated docs pages

- GitHub Ocean Examples (`/build-your-software-catalog/sync-data-to-catalog/git/github-ocean/examples/examples.md`)
- GitHub Repository Teams Example Config (`/build-your-software-catalog/sync-data-to-catalog/git/github-ocean/examples/example-repository-teams/_github_exporter_example_repository_with_teams_port_app_config.mdx`)
- GitHub Repository Collaborators Example Config (`/build-your-software-catalog/sync-data-to-catalog/git/github-ocean/examples/example-repository-collaborators/_github_exporter_example_repository_collaborator_port_app_config.mdx`)
