### PR TITLE
Added an explanation on new cancel request feature

### DIFF
--- a/docs/actions-and-automations/reflect-action-progress/reflect-action-progress.md
+++ b/docs/actions-and-automations/reflect-action-progress/reflect-action-progress.md
@@ -188,6 +188,20 @@ If we want to add a final log entry and also mark the action run as successful, 
 
 A log message with the `terminationStatus` key can only be sent once for an action run. After it is sent, the run status is marked accordingly and the run can no longer be modified.
 
+#### Cancel execution request
+
+If a user executes a self-service action that requires approval, and the run's `Status` is still `Waiting for approval`, they can withdraw their request.
+
+To cancel a pending execution request:
+
+1. Click on the <img src="/img/icons/auditLogButton.svg" style={{"vertical-align": "text-top"}} className="not-zoom" /> button in the top-right corner of the page.
+2.  Go to the relevant **run page**.
+3. Click on the `...` button in the top-right corner of the run's `Details` window, then click on `Edit`.
+4. Change the `Status` to **FAILURE**.
+5. Click **Save**.
+
+The run will then be marked as failed, and will no longer require approval or be eligible for execution.
+
 ## Tying Entities to an action run
 
 You can also add additional context and metadata to an action run by attaching a `run_id` query parameter to every API route that creates or changes an entity (i.e. [`POST`](/api-reference/create-an-entity), [`PUT`](/api-reference/change-an-entity), [`PATCH`](/api-reference/update-an-entity) and [`DELETE`](/api-reference/delete-an-entity) entity requests).  


### PR DESCRIPTION
# Description

Added an explanation on new feature that allows users to change an run status to failure if they no longer want to execute it.

## Updated docs pages

- https://docs.port.io/actions-and-automations/create-self-service-experiences/set-self-service-actions-rbac/
