### PR TITLE
Bug | PORT-15901-Added integration guidance for user status in RBAC documentation

### DIFF
--- a/docs/sso-rbac/rbac/rbac.md
+++ b/docs/sso-rbac/rbac/rbac.md
@@ -145,6 +145,10 @@ By default, all new users are created with the `Disabled` status (no email invit
 In your software catalog, admins can access the [Users](https://app.getport.io/_users) page to view and manage all of the user entities in the organization.  
 Here admins can also change a user's status, and invite new users.
 
+:::tip Integration and GitOps status behavior
+When creating users via integrations or GitOps workflows, the `status` field is optional and should typically be omitted. Port automatically manages user status based on authentication events. 
+:::
+
 #### Limitations
 
 - Only users with a UI/API origin can invite users and change their status.  


### PR DESCRIPTION
# Description

- Added integration guidance for user status in RBAC documentation
- Included a note on the optional `status` field when creating users via integrations or GitOps workflows.
- Clarified that Port manages user status based on authentication events.

## Added docs pages

Please also include the path for the added docs

- None

## Updated docs pages

Please also include the path for the updated docs

- User & team management (`/sso-rbac/rbac/#user-status`)
