### PR TITLE
Bug | PORT-15667 Added caution note for merge request access in GitLab integration documentation

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
@@ -57,6 +57,11 @@ You can use the following Port blueprint definitions and integration configurati
 
 ## Mapping projects, README.md and merge requests
 
+:::caution Merge request access requirement
+Merge requests are fetched at the **group level**. Ensure your integration token has access to the parent GitLab group that contains your projects. Project-level access alone is not sufficient for merge request visibility.
+:::
+
+
 The following example demonstrates how to ingest your GitLab projects, their README.md file contents and merge requests to Port.  
 You can use the following Port blueprint definitions and integration configuration:
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples.md
@@ -59,6 +59,9 @@ You can use the following Port blueprint definitions and integration configurati
 
 :::caution Merge request access requirement
 Merge requests are fetched at the **group level**. Ensure your integration token has access to the parent GitLab group that contains your projects. Project-level access alone is not sufficient for merge request visibility.
+
+For more information, see the [troubleshooting](/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/installation#troubleshooting) section.
+
 :::
 
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/installation.md
@@ -397,3 +397,34 @@ ingest_data:
 </TabItem>
 
 </Tabs>
+
+## Troubleshooting
+
+<h3>Merge requests not appearing in catalog</h3>
+
+If you can see your GitLab repositories in Port but merge requests are missing, this is likely due to insufficient group-level permissions.
+
+<h4>Symptoms</h4>
+- ✅ GitLab projects/repositories are visible in Port.
+- ❌ Merge requests are missing from the catalog.
+- ❌ No error messages in integration logs.
+
+<h4>Root cause</h4>
+The GitLab V2 integration fetches merge requests using **group-level API queries**. If your integration token only has access to individual projects (e.g., Developer or Maintainer role at the project level), it cannot access the group-level merge request data.
+
+<h4>Solution</h4>
+Ensure your integration token has access to the **parent GitLab group** that contains your projects:
+
+  - **For Personal Access Tokens**: The user must be a member of the group with at least Guest-level access.
+
+  - **For Group Access Tokens**: Create the token in the parent group with appropriate scopes.
+
+  - **For Service Account Tokens**: Add the service account to the group with at least Guest-level access.
+
+<h4>Verification</h4>
+To verify your token has the correct permissions:
+
+  - Test the token against GitLab's group API: `GET /api/v4/groups/{group_id}/merge_requests`
+  - Ensure the token can list merge requests at the group level.
+  - Check that the group is accessible with your current token permissions.
+


### PR DESCRIPTION

# Description

- Added caution note for merge request access in GitLab integration documentation
- Included a warning about the necessity of group-level access for fetching merge requests.
- Clarified that project-level access is insufficient for visibility of merge requests.

## Added docs pages

Please also include the path for the added docs

- None
## Updated docs pages

Please also include the path for the updated docs

- GitLabV2 (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/installation#troubleshooting`)
- GitLabV2 Examples (`/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/examples#mapping-projects-readmemd-and-merge-requests`)
