### PR TITLE
Portn 3647 add gitlab to azure installation

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/_azure_docker_params.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/_azure_docker_params.mdx
@@ -1,11 +1,11 @@
-| Parameter                             | Description                                                                                                        | Required |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------- |
-| `OCEAN__PORT__CLIENT_ID`              | Your port client id                                                                                                | ✅       |
-| `OCEAN__PORT__CLIENT_SECRET`          | Your port client secret                                                                                            | ✅       |
-| `OCEAN__PORT__BASE_URL`               | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US                            | ✅       |
-| `OCEAN__SECRET__AZURE_CLIENT_ID`      | Your Azure client ID                                                                                               | ✅       |
-| `OCEAN__SECRET__AZURE_CLIENT_SECRET`  | Your Azure client secret                                                                                           | ✅       |
-| `OCEAN__SECRET__AZURE_TENANT_ID`      | Your Azure tenant ID                                                                                               | ✅       |
-| `OCEAN__INITIALIZE_PORT_RESOURCES`    | Default true, When set to false the integration will not create default blueprints and the port App config Mapping | ❌       |
-| `OCEAN__SEND_RAW_DATA_EXAMPLES`        | Enable sending raw data examples from the third party API to port for testing and managing the integration mapping. Default is true                        | ❌       |
-| `OCEAN__INTEGRATION__IDENTIFIER`      | Change the identifier to describe your integration, if not set will use the default one                            | ❌       |
+| Parameter                             | Description                                                                                                         | Required |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- |
+| `OCEAN__PORT__CLIENT_ID`              | Your port client id.                                                                                                | ✅       |
+| `OCEAN__PORT__CLIENT_SECRET`          | Your port client secret.                                                                                            | ✅       |
+| `OCEAN__PORT__BASE_URL`               | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US.                            | ✅       |
+| `OCEAN__SECRET__AZURE_CLIENT_ID`      | Your Azure client ID.                                                                                               | ✅       |
+| `OCEAN__SECRET__AZURE_CLIENT_SECRET`  | Your Azure client secret.                                                                                           | ✅       |
+| `OCEAN__SECRET__AZURE_TENANT_ID`      | Your Azure tenant ID.                                                                                               | ✅       |
+| `OCEAN__INITIALIZE_PORT_RESOURCES`    | Default true, When set to false the integration will not create default blueprints and the port App config Mapping. | ❌       |
+| `OCEAN__SEND_RAW_DATA_EXAMPLES`        | Enable sending raw data examples from the third party API to port for testing and managing the integration mapping. Default is true.                        | ❌       |
+| `OCEAN__INTEGRATION__IDENTIFIER`      | Change the identifier to describe your integration, if not set will use the default one.                            | ❌       |

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation.md
@@ -325,6 +325,65 @@ kubectl apply -f azure-integration.yaml
 
 </TabItem>
 
+<TabItem value="gitlab" label="GitLab">
+
+Make sure to [configure the following GitLab variables](https://docs.gitlab.com/ee/ci/variables/#for-a-project):
+
+| Parameter                             | Description                                                                                                         | Required |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- |
+| `OCEAN__PORT__CLIENT_ID`              | Your port client id.                                                                                                | ✅       |
+| `OCEAN__PORT__CLIENT_SECRET`          | Your port client secret.                                                                                            | ✅       |
+| `OCEAN__PORT__BASE_URL`               | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US.                            | ✅       |
+| `OCEAN__SECRET__AZURE_CLIENT_ID`      | Your Azure client ID.                                                                                               | ✅       |
+| `OCEAN__SECRET__AZURE_CLIENT_SECRET`  | Your Azure client secret.                                                                                           | ✅       |
+| `OCEAN__SECRET__AZURE_TENANT_ID`      | Your Azure tenant ID.                                                                                               | ✅       |
+| `OCEAN__INITIALIZE_PORT_RESOURCES`    | Default true, When set to false the integration will not create default blueprints and the port App config Mapping. | ❌       |
+| `OCEAN__SEND_RAW_DATA_EXAMPLES`        | Enable sending raw data examples from the third party API to port for testing and managing the integration mapping. Default is true.                        | ❌       |
+| `OCEAN__INTEGRATION__IDENTIFIER`      | Change the identifier to describe your integration, if not set will use the default one.                            | ❌       |
+
+<br/>
+
+Here is an example for `.gitlab-ci.yml` pipeline file:
+
+```yaml showLineNumbers
+default:
+  image: docker:24.0.5
+  services:
+    - docker:24.0.5-dind
+  before_script:
+    - docker info
+
+variables:
+  INTEGRATION_TYPE: azure
+  VERSION: latest
+
+stages:
+  - ingest
+
+ingest_data:
+  stage: ingest
+  variables:
+    IMAGE_NAME: ghcr.io/port-labs/port-ocean-$INTEGRATION_TYPE:$VERSION
+  script:
+    - |
+        docker run -i --rm --platform=linux/amd64 \
+          -e OCEAN__PORT__CLIENT_ID=$PORT_CLIENT_ID \
+          -e OCEAN__PORT__CLIENT_SECRET=$PORT_CLIENT_SECRET \
+          -e OCEAN__PORT__BASE_URL="https://api.port.io" \
+          -e OCEAN__INITIALIZE_PORT_RESOURCES=true \
+          -e OCEAN__SEND_RAW_DATA_EXAMPLES=true \
+          -e OCEAN__EVENT_LISTENER='{"type": "ONCE"}' \
+          -e OCEAN__INTEGRATION__CONFIG__AZURE_CLIENT_ID="Enter value here" \
+          -e OCEAN__INTEGRATION__CONFIG__AZURE_CLIENT_SECRET="Enter value here" \
+          -e OCEAN__INTEGRATION__CONFIG__AZURE_TENANT_ID="Enter value here" \
+          $IMAGE_NAME
+
+  rules: # Run only when changes are made to the main branch
+    - if: '$CI_COMMIT_BRANCH == "main"'
+```
+
+</TabItem>
+
 </Tabs>
 
 </TabItem>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation.md
@@ -329,21 +329,17 @@ kubectl apply -f azure-integration.yaml
 
 Make sure to [configure the following GitLab variables](https://docs.gitlab.com/ee/ci/variables/#for-a-project):
 
-| Parameter                             | Description                                                                                                         | Required |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- |
-| `OCEAN__PORT__CLIENT_ID`              | Your port client id.                                                                                                | ✅       |
-| `OCEAN__PORT__CLIENT_SECRET`          | Your port client secret.                                                                                            | ✅       |
-| `OCEAN__PORT__BASE_URL`               | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US.                            | ✅       |
-| `OCEAN__SECRET__AZURE_CLIENT_ID`      | Your Azure client ID.                                                                                               | ✅       |
-| `OCEAN__SECRET__AZURE_CLIENT_SECRET`  | Your Azure client secret.                                                                                           | ✅       |
-| `OCEAN__SECRET__AZURE_TENANT_ID`      | Your Azure tenant ID.                                                                                               | ✅       |
-| `OCEAN__INITIALIZE_PORT_RESOURCES`    | Default true, When set to false the integration will not create default blueprints and the port App config Mapping. | ❌       |
-| `OCEAN__SEND_RAW_DATA_EXAMPLES`        | Enable sending raw data examples from the third party API to port for testing and managing the integration mapping. Default is true.                        | ❌       |
-| `OCEAN__INTEGRATION__IDENTIFIER`      | Change the identifier to describe your integration, if not set will use the default one.                            | ❌       |
-| `OCEAN__EVENT_LISTENER`               | [The event listener object](https://ocean.getport.io/framework/features/event-listener/). | |
-| `OCEAN__INTEGRATION__CONFIG__AZURE_CLIENT_ID` | The client ID of the Azure App Registration.| |
-| `OCEAN__INTEGRATION__CONFIG__AZURE_CLIENT_SECRET` | The client secret of the Azure App Registration. | |
-| `OCEAN__INTEGRATION__CONFIG__AZURE_TENANT_ID` | The tenant ID of the Azure App Registration. | |
+| Parameter                                     | Description                                                                                                                           | Required |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `OCEAN__PORT__CLIENT_ID`                      | Your port client id.                                                                                                                  | ✅       |
+| `OCEAN__PORT__CLIENT_SECRET`                  | Your port client secret.                                                                                                              | ✅       |
+| `OCEAN__PORT__BASE_URL`                       | Your Port API URL - `https://api.getport.io` for EU, `https://api.us.getport.io` for US.                                              | ✅       |
+| `OCEAN__INTEGRATION__CONFIG__AZURE_CLIENT_ID` | The client ID of the Azure App Registration.                                                                                          | ✅       |
+| `OCEAN__INTEGRATION__CONFIG__AZURE_CLIENT_SECRET` | The client secret of the Azure App Registration.                                                                                  | ✅       |
+| `OCEAN__INTEGRATION__CONFIG__AZURE_TENANT_ID` | The tenant ID of the Azure App Registration.                                                                                          | ✅       |
+| `OCEAN__INITIALIZE_PORT_RESOURCES`            | Default true, when set to false the integration will not create default blueprints and the port App config mapping.                   | ❌       |
+| `OCEAN__SEND_RAW_DATA_EXAMPLES`               | Enable sending raw data examples from the third party API to port for testing and managing the integration mapping. Default is true.  | ❌       |
+| `OCEAN__EVENT_LISTENER`                       | [The event listener object](https://ocean.getport.io/framework/features/event-listener/).                                             | ❌       |
 
 <br/>
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation.md
@@ -340,6 +340,10 @@ Make sure to [configure the following GitLab variables](https://docs.gitlab.com/
 | `OCEAN__INITIALIZE_PORT_RESOURCES`    | Default true, When set to false the integration will not create default blueprints and the port App config Mapping. | ❌       |
 | `OCEAN__SEND_RAW_DATA_EXAMPLES`        | Enable sending raw data examples from the third party API to port for testing and managing the integration mapping. Default is true.                        | ❌       |
 | `OCEAN__INTEGRATION__IDENTIFIER`      | Change the identifier to describe your integration, if not set will use the default one.                            | ❌       |
+| `OCEAN__EVENT_LISTENER`               | [The event listener object](https://ocean.getport.io/framework/features/event-listener/). | |
+| `OCEAN__INTEGRATION__CONFIG__AZURE_CLIENT_ID` | The client ID of the Azure App Registration.| |
+| `OCEAN__INTEGRATION__CONFIG__AZURE_CLIENT_SECRET` | The client secret of the Azure App Registration. | |
+| `OCEAN__INTEGRATION__CONFIG__AZURE_TENANT_ID` | The tenant ID of the Azure App Registration. | |
 
 <br/>
 


### PR DESCRIPTION
# Description

Added a tab for the gitlab CI integration with Azure.

## Updated docs pages

- https://docs.port.io/build-your-software-catalog/sync-data-to-catalog/cloud-providers/azure/installation?installation-methods=ci#installation-methods
