### PR TITLE
Add access control section to GitLab integration documentation

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
@@ -50,6 +50,9 @@ This is the default mapping configuration for this integration:
 ```yaml showLineNumbers
 deleteDependentEntities: true
 createMissingRelatedEntities: true
+visibility:
+  useMinAccessLevel: true
+  minAccessLevel: 30
 resources:
 - kind: project
   selector:
@@ -118,7 +121,17 @@ resources:
 
 </details>
 
+## Access control
 
+The GitLab integration supports configurable access control to determine which resources are visible and accessible to the integration.
+
+We can configure access control using the `visibility` configuration block in the integration mapping. 
+
+This allows us to filter resources based on GitLab access levels (Guest, Reporter, Developer, Maintainer, Owner). We can also disable access level filtering entirely to include all accessible resources.
+
+:::tip Access control configuration
+For detailed configuration options, access level reference, and practical examples, check the [Advanced configuration](./advanced.md#access-control) section.
+:::
 
 ## Capabilities
 

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/advanced.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/advanced.md
@@ -59,4 +59,67 @@ The `createMissingRelatedEntities` parameter enables automatic creation of place
 
 </TabItem>
 
+<TabItem value="accessControl" label="Access control">
+
+The `visibility` configuration allows us to control which GitLab resources are accessible to the integration based on access levels.
+
+<h3>Access levels</h3>
+
+GitLab uses numeric access levels to define permissions:
+
+| Level | Role | Description |
+|-------|------|-------------|
+| 10 | Guest | Read-only access to public resources |
+| 20 | Reporter | Can view and download code |
+| 30 | Developer | Can push code and manage issues |
+| 40 | Maintainer | Can manage project settings |
+| 50 | Owner | Full administrative access |
+
+<h3>Parameters</h3>
+
+- **`useMinAccessLevel`**: Boolean flag to enable/disable access level filtering
+  - **Default value**: `true`
+  - **Use case**: Set to `false` to include all accessible resources without filtering
+
+- **`minAccessLevel`**: Integer specifying minimum access level required
+  - **Default value**: `30` (Developer)
+  - **Use case**: Restrict integration to resources where the token has specified access level or higher
+
+<h3>Configuration examples</h3>
+
+```yaml showLineNumbers
+# Only sync owned projects
+visibility:
+  useMinAccessLevel: true
+  minAccessLevel: 50
+resources:
+  - kind: project
+    selector:
+      query: 'true'
+    port:
+      entity:
+        mappings:
+          identifier: .path_with_namespace | gsub(" "; "")
+          title: .name
+          blueprint: '"service"'
+```
+
+```yaml showLineNumbers
+# Include all accessible resources
+visibility:
+  useMinAccessLevel: false
+resources:
+  - kind: project
+    selector:
+      query: 'true'
+    port:
+      entity:
+        mappings:
+          identifier: .path_with_namespace | gsub(" "; "")
+          title: .name
+          blueprint: '"service"'
+```
+
+</TabItem>
+
 </Tabs>


### PR DESCRIPTION
Enhance the GitLab integration documentation by introducing an access control section. This includes details on the `visibility` configuration, access levels, and parameters for filtering resources based on user permissions. Configuration examples are provided for both restricted and unrestricted access scenarios.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

## Added docs pages

Please also include the path for the added docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...

## Updated docs pages

Please also include the path for the updated docs

- Quickstart (`/`)
- Blueprint (`/platform-overview/port-components/blueprint`)
- ...
