### PR TITLE
change the default mapping of gitlab-v2 to gitlabRepository from service

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/GitLab-v2.md
@@ -60,7 +60,7 @@ resources:
       mappings:
         identifier: .path_with_namespace | gsub(" "; "")
         title: .name
-        blueprint: '"service"'
+        blueprint: '"gitlabRepository"'
         properties:
           url: .web_url
           readme: file://README.md


### PR DESCRIPTION
# Description

Handled the following JIRA issue: https://getport.atlassian.net/browse/PORT-16339

In the default mapping given for GitLab V2, under the project kind, changed the blueprint identifier from service to gitlabRepository.

## Updated docs pages

- https://docs.port.io/build-your-software-catalog/sync-data-to-catalog/git/gitlab-v2/#default-mapping-configuration